### PR TITLE
Enable nix flakes on all CI runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,14 +167,13 @@ jobs:
           GC_DONT_GC: '1'
         run: |
           export JQ=$(nix-build '<nixpkgs>' -A jq --no-link)/bin/jq
-          booster=$(nix build .#hs-backend-booster:exe:hs-backend-booster --json | $JQ -r '.[].outputs | to_entries[].value')
+          booster=$(nix build .#hs-backend-booster:exe:hs-backend-booster --extra-experimental-features 'nix-command flakes' --json | $JQ -r '.[].outputs | to_entries[].value')
           drv=$(nix-store --query --deriver ${booster})
           nix-store --query --requisites --include-outputs ${drv} | cachix push runtimeverification
-          # cachix watch-exec runtimeverification -- nix build .#hs-backend-booster:exe:hs-backend-booster
-          nix build .#hs-backend-booster:exe:parsetest
-          nix build .#hs-backend-booster:exe:rpc-client
+          nix build .#hs-backend-booster:exe:parsetest --extra-experimental-features 'nix-command flakes'
+          nix build .#hs-backend-booster:exe:rpc-client --extra-experimental-features 'nix-command flakes'
 
       - name: Run unit tests
         env:
           GC_DONT_GC: '1'
-        run: nix build .#hs-backend-booster:test:test-suite
+        run: nix build .#hs-backend-booster:test:test-suite --extra-experimental-features 'nix-command flakes'


### PR DESCRIPTION
Some self hosted runners don't seem to have the experimental nix flake CLI enabled. This should fix the issue.