### PR TITLE
Call FFI functions with an extra string len argument to prevent trucation

### DIFF
--- a/cbits/kllvm-c.h
+++ b/cbits/kllvm-c.h
@@ -51,8 +51,12 @@ char *kore_pattern_dump(kore_pattern const *);
 void kore_pattern_free(kore_pattern const *);
 
 kore_pattern *kore_pattern_new_token(char const *, kore_sort const *);
+kore_pattern *
+kore_pattern_new_token_with_len(char const *, size_t, kore_sort const *);
+
 kore_pattern *kore_pattern_new_injection(
     kore_pattern *, kore_sort const *, kore_sort const *);
+
 kore_pattern *kore_pattern_make_interpreter_input(kore_pattern *);
 
 kore_pattern *kore_composite_pattern_new(char const *);
@@ -60,6 +64,7 @@ kore_pattern *kore_composite_pattern_from_symbol(kore_symbol *);
 void kore_composite_pattern_add_argument(kore_pattern *, kore_pattern *);
 
 kore_pattern *kore_string_pattern_new(char const *);
+kore_pattern *kore_string_pattern_new_with_len(char const *, size_t);
 
 block *kore_pattern_construct(kore_pattern const *);
 char *kore_block_dump(block *);
@@ -86,6 +91,8 @@ char *kore_sort_dump(kore_sort const *);
 void kore_sort_free(kore_sort const *);
 
 bool kore_sort_is_concrete(kore_sort const *);
+
+bool kore_sort_is_kitem(kore_sort const *);
 
 kore_sort *kore_composite_sort_new(char const *);
 void kore_composite_sort_add_argument(kore_sort const *, kore_sort const *);

--- a/library/Kore/LLVM/Internal.hs
+++ b/library/Kore/LLVM/Internal.hs
@@ -101,14 +101,15 @@ runLLVMwithDL dlib (LLVM m) = flip runReaderT dlib $ do
                 pure parent
 
         string <- do
-            newString <- koreStringPatternNew
-            pure $ KoreStringPatternAPI $ \name -> liftIO $ C.withCString (Text.unpack name) $ newString >=> newForeignPtr freePattern
+            newString <- koreStringPatternNewWithLen
+            pure $ KoreStringPatternAPI $ \name -> liftIO $ C.withCStringLen (Text.unpack name) $ \(rawStr, len) ->
+                newString rawStr (fromIntegral len) >>= newForeignPtr freePattern
 
         token <- do
-            newToken <- korePatternNewToken
-            pure $ KoreTokenPatternAPI $ \name sort -> liftIO $ C.withCString (Text.unpack name) $ \rawName ->
+            newToken <- korePatternNewTokenWithLen
+            pure $ KoreTokenPatternAPI $ \name sort -> liftIO $ C.withCStringLen (Text.unpack name) $ \(rawName, len) ->
                 withForeignPtr sort $
-                    newToken rawName >=> newForeignPtr freePattern
+                    newToken rawName (fromIntegral len) >=> newForeignPtr freePattern
 
         fromSymbol <- do
             compositePatternFromSymbol <- koreCompositePatternFromSymbol


### PR DESCRIPTION
The string data being passed to the LLVM backend may contail null. To avoid trucation of such data, we should always call the `with_len` API function. This fixes https://github.com/runtimeverification/llvm-backend/issues/629 on the Haskell side, ( the fix on LLVM side was https://github.com/runtimeverification/llvm-backend/pull/631).