### PR TITLE
Add term attributes / Avoid calling the LLVM simplification

### DIFF
--- a/library/Kore/JsonRpc.hs
+++ b/library/Kore/JsonRpc.hs
@@ -80,7 +80,7 @@ respond def@KoreDefinition{} mLlvmLibrary =
 
         _ -> pure $ Left $ ErrorObj "Not implemented" (-32601) Null
   where
-    execResponse :: (Natural, RewriteResult) -> Either ErrorObj (API 'Res)
+    execResponse :: (Natural, RewriteResult Pattern) -> Either ErrorObj (API 'Res)
     execResponse (_, RewriteSingle{}) =
         error "Single rewrite result"
     execResponse (d, RewriteBranch p nexts) =

--- a/library/Kore/LLVM/Internal.hs
+++ b/library/Kore/LLVM/Internal.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -Wno-unused-top-binds #-}
-{-# OPTIONS_GHC -ddump-splices #-}
 
 module Kore.LLVM.Internal (API (..), KorePatternAPI (..), runLLVM, runLLVMwithDL, withDLib, ask, marshallTerm, marshallSort) where
 

--- a/library/Kore/Pattern/Base.hs
+++ b/library/Kore/Pattern/Base.hs
@@ -27,10 +27,6 @@ import Kore.Prettyprinter qualified as KPretty
 import Prettyprinter (Pretty (..))
 import Prettyprinter qualified as Pretty
 
-----------------------------------------
-
-----------------------------------------
-
 type VarName = Text
 type SymbolName = Text
 type SortName = Text

--- a/library/Kore/Pattern/Base.hs
+++ b/library/Kore/Pattern/Base.hs
@@ -21,18 +21,18 @@ import Data.Text (Text)
 import Data.Text qualified as Text
 import GHC.Generics (Generic)
 import Kore.Definition.Attributes.Base (
-    SymbolAttributes,
-    SymbolType (..),
     SymbolAttributes (..),
-  )
+    SymbolType (..),
+ )
 import Kore.Prettyprinter qualified as KPretty
 import Prettyprinter (Pretty (..))
 import Prettyprinter qualified as Pretty
 
 ----------------------------------------
---import Control.Comonad.Trans.Cofree
+-- import Control.Comonad.Trans.Cofree
 import Data.Set (Set)
 import Data.Set qualified as Set
+
 ----------------------------------------
 
 type VarName = Text
@@ -79,6 +79,7 @@ data Symbol = Symbol
    Deliberately kept simple in this codebase (leaving out built-in
    types and containers).
 -}
+
 -- data Term
 --     = AndTerm Term Term -- used in #as patterns
 --     | SymbolApplication Symbol [Sort] [Term]
@@ -94,7 +95,7 @@ data TermF t
     | DomainValueF Sort Text
     | VarF Variable
     deriving stock (Eq, Ord, Show, Functor, Foldable, Traversable, Generic)
-    deriving anyclass NFData
+    deriving anyclass (NFData)
 
 type instance Base Term = TermF
 
@@ -109,27 +110,26 @@ instance Corecursive Term where
 
 ----------------------------------------
 
-data TermAttributes =
-    TermAttributes
+data TermAttributes = TermAttributes
     { variables :: Set Variable
     , isEvaluated :: Bool
     }
     deriving stock (Eq, Ord, Show, Generic)
-    deriving anyclass NFData
+    deriving anyclass (NFData)
 
 instance Semigroup TermAttributes where
     a1 <> a2 =
         TermAttributes
-        { variables = a1.variables <> a2.variables
-        , isEvaluated = a1.isEvaluated && a2.isEvaluated
-        }
+            { variables = a1.variables <> a2.variables
+            , isEvaluated = a1.isEvaluated && a2.isEvaluated
+            }
 
 instance Monoid TermAttributes where
     mempty = TermAttributes Set.empty True
 
 data Term = Term TermAttributes (TermF Term)
     deriving stock (Eq, Ord, Show, Generic)
-    deriving anyclass NFData
+    deriving anyclass (NFData)
 
 extract :: Term -> TermAttributes
 extract (Term a _) = a
@@ -138,38 +138,37 @@ extract (Term a _) = a
 -- smart term constructors, as bidirectional patterns
 pattern AndTerm :: Term -> Term -> Term
 pattern AndTerm t1 t2 <- Term _ (AndTermF t1 t2)
-  where
-    AndTerm t1@(Term a1 _) t2@(Term a2 _) = Term (a1 <> a2) $ AndTermF t1 t2
+    where
+        AndTerm t1@(Term a1 _) t2@(Term a2 _) = Term (a1 <> a2) $ AndTermF t1 t2
 
 pattern SymbolApplication :: Symbol -> [Sort] -> [Term] -> Term
 pattern SymbolApplication sym sorts args <- Term _ (SymbolApplicationF sym sorts args)
-  where
-    SymbolApplication sym sorts args =
-        let
-            argAttributes = mconcat $ map extract args
-            newEvaluatedFlag =
-                case sym.attributes.symbolType of
-                    -- constructors and injections are evaluated if their arguments are
-                    Constructor -> argAttributes.isEvaluated
-                    SortInjection -> argAttributes.isEvaluated
-                    -- function calls are not evaluated
-                    PartialFunction -> False
-                    TotalFunction -> False
-        in Term argAttributes { isEvaluated = newEvaluatedFlag } $
-            SymbolApplicationF sym sorts args
-
+    where
+        SymbolApplication sym sorts args =
+            let argAttributes = mconcat $ map extract args
+                newEvaluatedFlag =
+                    case sym.attributes.symbolType of
+                        -- constructors and injections are evaluated if their arguments are
+                        Constructor -> argAttributes.isEvaluated
+                        SortInjection -> argAttributes.isEvaluated
+                        -- function calls are not evaluated
+                        PartialFunction -> False
+                        TotalFunction -> False
+             in Term argAttributes{isEvaluated = newEvaluatedFlag} $
+                    SymbolApplicationF sym sorts args
 
 pattern DomainValue :: Sort -> Text -> Term
 pattern DomainValue sort value <- Term _ (DomainValueF sort value)
-  where
-    DomainValue sort value = Term mempty $ DomainValueF sort value
+    where
+        DomainValue sort value = Term mempty $ DomainValueF sort value
 
 pattern Var :: Variable -> Term
 pattern Var v <- Term _ (VarF v)
-  where
-    Var v = Term mempty{variables = Set.singleton v} (VarF v)
+    where
+        Var v = Term mempty{variables = Set.singleton v} (VarF v)
 
 {-# COMPLETE AndTerm, SymbolApplication, DomainValue, Var #-}
+
 ----------------------------------------
 --------------------
 

--- a/library/Kore/Pattern/Base.hs
+++ b/library/Kore/Pattern/Base.hs
@@ -113,8 +113,8 @@ type instance Base Term = TermF
 instance Recursive Term where
     project (Term _ t) = t
 
-extract :: Term -> TermAttributes
-extract (Term a _) = a
+getAttributes :: Term -> TermAttributes
+getAttributes (Term a _) = a
 
 instance Corecursive Term where
     embed (AndTermF t1 t2) = AndTerm t1 t2
@@ -132,7 +132,7 @@ pattern SymbolApplication :: Symbol -> [Sort] -> [Term] -> Term
 pattern SymbolApplication sym sorts args <- Term _ (SymbolApplicationF sym sorts args)
     where
         SymbolApplication sym sorts args =
-            let argAttributes = mconcat $ map extract args
+            let argAttributes = mconcat $ map getAttributes args
                 newEvaluatedFlag =
                     case sym.attributes.symbolType of
                         -- constructors and injections are evaluated if their arguments are

--- a/library/Kore/Pattern/Base.hs
+++ b/library/Kore/Pattern/Base.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 {- |
 Copyright   : (c) Runtime Verification, 2022
@@ -13,6 +14,7 @@ module Kore.Pattern.Base (
 import Control.DeepSeq (NFData (..))
 import Data.Either (fromRight)
 import Data.Functor.Foldable
+import Data.Functor.Foldable.TH (makeBaseFunctor)
 import Data.Map qualified as Map
 import Data.Set (Set)
 import Data.Set qualified as Set
@@ -188,50 +190,7 @@ data Predicate
     deriving stock (Eq, Ord, Show, Generic)
     deriving anyclass (NFData)
 
-data PredicateF p
-    = AndPredicateF p p
-    | BottomF
-    | CeilF Term
-    | EqualsTermF Term Term
-    | EqualsPredicateF p p
-    | ExistsF VarName p
-    | ForallF VarName p
-    | IffF p p
-    | ImpliesF p p
-    | InF Term Term
-    | NotF p
-    | OrF p p
-    | TopF
-    deriving (Functor, Foldable, Traversable)
-type instance Base Predicate = PredicateF
-instance Recursive Predicate where
-    project (AndPredicate p1 p2) = AndPredicateF p1 p2
-    project Bottom = BottomF
-    project (Ceil t) = CeilF t
-    project (EqualsTerm t1 t2) = EqualsTermF t1 t2
-    project (EqualsPredicate p1 p2) = EqualsPredicateF p1 p2
-    project (Exists v p) = ExistsF v p
-    project (Forall v p) = ForallF v p
-    project (Iff p1 p2) = IffF p1 p2
-    project (Implies p1 p2) = ImpliesF p1 p2
-    project (In t1 t2) = InF t1 t2
-    project (Not p) = NotF p
-    project (Or p1 p2) = OrF p1 p2
-    project Top = TopF
-instance Corecursive Predicate where
-    embed (AndPredicateF p1 p2) = AndPredicate p1 p2
-    embed BottomF = Bottom
-    embed (CeilF t) = Ceil t
-    embed (EqualsTermF t1 t2) = EqualsTerm t1 t2
-    embed (EqualsPredicateF p1 p2) = EqualsPredicate p1 p2
-    embed (ExistsF v p) = Exists v p
-    embed (ForallF v p) = Forall v p
-    embed (IffF p1 p2) = Iff p1 p2
-    embed (ImpliesF p1 p2) = Implies p1 p2
-    embed (InF t1 t2) = In t1 t2
-    embed (NotF p) = Not p
-    embed (OrF p1 p2) = Or p1 p2
-    embed TopF = Top
+makeBaseFunctor ''Predicate
 
 --------------------
 

--- a/library/Kore/Pattern/Rewrite.hs
+++ b/library/Kore/Pattern/Rewrite.hs
@@ -81,7 +81,7 @@ rewriteStep cutLabels terminalLabels pat = do
   where
     processGroups :: [[RewriteRule]] -> RewriteM RewriteFailed (RewriteResult Pattern)
     processGroups [] =
-        throw $ NoApplicableRules
+        throw NoApplicableRules
     processGroups (rules : rest) = do
         -- try all rules of the priority group
         (failures, results) <-

--- a/library/Kore/Pattern/Rewrite.hs
+++ b/library/Kore/Pattern/Rewrite.hs
@@ -366,7 +366,6 @@ performRewrite ::
     io (Natural, RewriteResult Pattern)
 performRewrite def mLlvmLibrary mbMaxDepth cutLabels terminalLabels pat = do
     logRewrite $ "Rewriting pattern " <> prettyText pat
-    -- FIXME could simplify here and log simplified pattern
     doSteps False 0 pat
   where
     logRewrite = logOther (LevelOther "Rewrite")

--- a/library/Kore/Pattern/Rewrite.hs
+++ b/library/Kore/Pattern/Rewrite.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveFunctor #-}
+
 {- |
 Copyright   : (c) Runtime Verification, 2022
 License     : BSD-3-Clause
@@ -298,16 +300,7 @@ data RewriteResult pat
       -- (signalled by exceptions)
       RewriteAborted pat
     deriving stock (Eq, Show)
-
-instance Functor RewriteResult where
-    fmap f = \case
-        RewriteSingle pat -> RewriteSingle $ f pat
-        RewriteBranch pat pats -> RewriteBranch (f pat) (NE.map f pats)
-        RewriteStuck pat -> RewriteStuck $ f pat
-        RewriteCutPoint lbl pat next -> RewriteCutPoint lbl (f pat) (f next)
-        RewriteTerminal lbl pat -> RewriteTerminal lbl $ f pat
-        RewriteStopped pat -> RewriteStopped $ f pat
-        RewriteAborted pat -> RewriteAborted $ f pat
+    deriving (Functor)
 
 instance Pretty (RewriteResult Pattern) where
     pretty (RewriteSingle pat) =

--- a/library/Kore/Pattern/Rewrite.hs
+++ b/library/Kore/Pattern/Rewrite.hs
@@ -60,7 +60,7 @@ getDL = RewriteM $ snd <$> ask
   failed), or a rewritten pattern with a new term and possibly new
   additional constraints.
 -}
-rewriteStep :: [Text] -> [Text] -> Pattern -> RewriteM RewriteFailed RewriteResult
+rewriteStep :: [Text] -> [Text] -> Pattern -> RewriteM RewriteFailed (RewriteResult Pattern)
 rewriteStep cutLabels terminalLabels pat = do
     let termIdx = computeTermIndex pat.term
     when (termIdx == None) $ throw TermIndexIsNone
@@ -79,7 +79,7 @@ rewriteStep cutLabels terminalLabels pat = do
     -- until a result is obtained or the entire rewrite fails.
     processGroups rules
   where
-    processGroups :: [[RewriteRule]] -> RewriteM RewriteFailed RewriteResult
+    processGroups :: [[RewriteRule]] -> RewriteM RewriteFailed (RewriteResult Pattern)
     processGroups [] =
         pure $ RewriteStuck pat
     processGroups (rules : rest) = do
@@ -276,26 +276,40 @@ isUncertain UnificationIsNotMatch{} = True
 isUncertain ConstraintIsBottom{} = False
 isUncertain ConstraintIsIndeterminate{} = True
 
+isUnificationUnclear :: RuleFailed -> Bool
+isUnificationUnclear RewriteUnificationUnclear{} = True
+isUnificationUnclear _other = False
+
 -- | Different rewrite results (returned from RPC execute endpoint)
-data RewriteResult
+data RewriteResult pat
     = -- | single result (internal use, not returned)
-      RewriteSingle Pattern
+      RewriteSingle pat
     | -- | branch point
-      RewriteBranch Pattern (NonEmpty Pattern)
+      RewriteBranch pat (NonEmpty pat)
     | -- | no rules could be applied, config is stuck
-      RewriteStuck Pattern
+      RewriteStuck pat
     | -- | cut point rule, return current (lhs) and single next state
-      RewriteCutPoint Text Pattern Pattern
+      RewriteCutPoint Text pat pat
     | -- | terminal rule, return rhs (final state reached)
-      RewriteTerminal Text Pattern
+      RewriteTerminal Text pat
     | -- | stopping because maximum depth has been reached
-      RewriteStopped Pattern
+      RewriteStopped pat
     | -- | unable to handle the current case with this rewriter
       -- (signalled by exceptions)
-      RewriteAborted Pattern
+      RewriteAborted pat
     deriving stock (Eq, Show)
 
-instance Pretty RewriteResult where
+instance Functor RewriteResult where
+    fmap f = \case
+        RewriteSingle pat -> RewriteSingle $ f pat
+        RewriteBranch pat pats -> RewriteBranch (f pat) (NE.map f pats)
+        RewriteStuck pat -> RewriteStuck $ f pat
+        RewriteCutPoint lbl pat next -> RewriteCutPoint lbl (f pat) (f next)
+        RewriteTerminal lbl pat -> RewriteTerminal lbl $ f pat
+        RewriteStopped pat -> RewriteStopped $ f pat
+        RewriteAborted pat -> RewriteAborted $ f pat
+
+instance Pretty (RewriteResult Pattern) where
     pretty (RewriteSingle pat) =
         showPattern "Rewritten to" pat
     pretty (RewriteBranch pat nexts) =
@@ -349,39 +363,54 @@ performRewrite ::
     -- | terminal rule labels
     [Text] ->
     Pattern ->
-    io (Natural, RewriteResult)
+    io (Natural, RewriteResult Pattern)
 performRewrite def mLlvmLibrary mbMaxDepth cutLabels terminalLabels pat = do
-    logRewrite $ "Rewriting pattern " <> pack (renderDefault $ pretty pat)
-    doSteps 0 pat
+    logRewrite $ "Rewriting pattern " <> prettyText pat
+    -- FIXME could simplify here and log simplified pattern
+    doSteps False 0 pat
   where
     logRewrite = logOther (LevelOther "Rewrite")
+
+    prettyText :: Pretty a => a -> Text
+    prettyText = pack . renderDefault . pretty
 
     depthReached n = maybe False (n >=) mbMaxDepth
 
     showCounter = (<> " steps.") . pack . show
 
-    doSteps :: Natural -> Pattern -> io (Natural, RewriteResult)
-    doSteps counter pat'
+    simplify :: Pattern -> Pattern
+    simplify p = p{term = simplifyConcrete mLlvmLibrary def p.term}
+
+    doSteps :: Bool -> Natural -> Pattern -> io (Natural, RewriteResult Pattern)
+    doSteps wasSimplified counter pat'
         | depthReached counter = do
             logRewrite $ "Reached maximum depth of " <> maybe "?" showCounter mbMaxDepth
-            pure (counter, RewriteStopped pat')
+            pure (counter, (if wasSimplified then id else fmap simplify) $ RewriteStopped pat')
         | otherwise = do
-            let simplifiedPat =
-                    pat'{term = simplifyConcrete mLlvmLibrary def pat'.term}
-                res =
+            let res =
                     runRewriteM def mLlvmLibrary $
-                        rewriteStep cutLabels terminalLabels simplifiedPat
+                        rewriteStep cutLabels terminalLabels pat'
             case res of
                 Right (RewriteSingle single) ->
-                    doSteps (counter + 1) single
+                    doSteps False (counter + 1) single
                 Right terminal@RewriteTerminal{} -> do
                     logRewrite $ "Terminal rule reached after " <> showCounter (counter + 1)
-                    pure (counter + 1, terminal)
+                    pure (counter + 1, fmap simplify terminal)
                 Right other -> do
                     logRewrite $ "Stopped after " <> showCounter counter
-                    logRewrite $ pack (renderDefault $ pretty other)
-                    pure (counter, other)
+                    let simplifiedOther = fmap simplify other
+                    logRewrite $ prettyText simplifiedOther
+                    pure (counter, simplifiedOther)
+                -- if unification was unclear and the pattern was
+                -- unsimplified, simplify and retry rewriting once
+                Left (RuleApplicationUncertain ruleFails)
+                    | any isUnificationUnclear ruleFails
+                    , not wasSimplified -> do
+                        let simplifiedPat = simplify pat'
+                        logRewrite $ "Unification unclear for " <> prettyText pat'
+                        logRewrite $ "Retrying with simplified pattern " <> prettyText simplifiedPat
+                        doSteps True counter simplifiedPat
                 Left failure -> do
                     logRewrite $ "Aborted after " <> showCounter counter
-                    logRewrite $ pack (renderDefault $ pretty failure)
-                    pure (counter, RewriteAborted pat')
+                    logRewrite $ prettyText failure
+                    pure (counter, (if wasSimplified then id else fmap simplify) $ RewriteAborted pat')

--- a/library/Kore/Pattern/Simplify.hs
+++ b/library/Kore/Pattern/Simplify.hs
@@ -73,15 +73,15 @@ simplifyConcrete (Just dl) def trm = recurse trm
         | isConcrete t =
             simplifyTerm dl def t (sortOfTerm t)
         | otherwise =
-              case t of
-                  var@Var{} ->
-                      var -- nothing to do. Should have isEvaluated set
-                  dv@DomainValue{} ->
-                      dv -- nothing to do. Should have isEvaluated set
-                  AndTerm t1 t2 ->
-                      AndTerm (recurse t1) (recurse t2)
-                  SymbolApplication sym sorts args ->
-                      SymbolApplication sym sorts (map recurse args)
+            case t of
+                var@Var{} ->
+                    var -- nothing to do. Should have isEvaluated set
+                dv@DomainValue{} ->
+                    dv -- nothing to do. Should have isEvaluated set
+                AndTerm t1 t2 ->
+                    AndTerm (recurse t1) (recurse t2)
+                SymbolApplication sym sorts args ->
+                    SymbolApplication sym sorts (map recurse args)
 
 -- FIXME recursions repeat runLLVMwithDL (no sharing). This is
 --  a more general problem with runLLVMwithDL, the library

--- a/library/Kore/Pattern/Simplify.hs
+++ b/library/Kore/Pattern/Simplify.hs
@@ -66,20 +66,22 @@ simplifyConcrete (Just dl) def trm = recurse trm
     -- recursion scheme for this?
     --     cata $ \case does not work here, would need helpers for TermF not Term
     --         t | isConcreteF t -> simplifyTerm dl def t (sortOfTerm t)
-    --         other -> embed other
-    recurse = \case
-        var@Var{} ->
-            var -- nothing to do
-        dv@DomainValue{} ->
-            dv -- nothing to do
-        t
-            | isConcrete t ->
-                -- FIXME repeats bottom-up traversal in isConcrete (needs cache)
-                simplifyTerm dl def t (sortOfTerm t)
-        AndTerm t1 t2 ->
-            AndTerm (recurse t1) (recurse t2)
-        SymbolApplication sym sorts args ->
-            SymbolApplication sym sorts (map recurse args)
+    --         other -> embed other\
+    recurse t@(Term attributes _)
+        | attributes.isEvaluated =
+            t
+        | isConcrete t =
+            simplifyTerm dl def t (sortOfTerm t)
+        | otherwise =
+              case t of
+                  var@Var{} ->
+                      var -- nothing to do. Should have isEvaluated set
+                  dv@DomainValue{} ->
+                      dv -- nothing to do. Should have isEvaluated set
+                  AndTerm t1 t2 ->
+                      AndTerm (recurse t1) (recurse t2)
+                  SymbolApplication sym sorts args ->
+                      SymbolApplication sym sorts (map recurse args)
 
 -- FIXME recursions repeat runLLVMwithDL (no sharing). This is
 --  a more general problem with runLLVMwithDL, the library

--- a/library/Kore/Pattern/Util.hs
+++ b/library/Kore/Pattern/Util.hs
@@ -22,7 +22,6 @@ module Kore.Pattern.Util (
     decodeLabel,
 ) where
 
-import Data.Foldable (fold)
 import Data.Functor.Foldable (Corecursive (embed), cata)
 import Data.Map (Map)
 import Data.Map qualified as Map
@@ -84,11 +83,8 @@ modifyVariables f p =
         other -> embed other
 
 freeVariables :: Term -> Set Variable
-freeVariables = cata $ \case
-    VarF var -> Set.singleton var
-    other -> fold other
+freeVariables (Term attributes _) = attributes.variables
 
--- | Don't use unless therm size is small
 isConcrete :: Term -> Bool
 isConcrete = Set.null . freeVariables
 

--- a/library/Kore/Pattern/Util.hs
+++ b/library/Kore/Pattern/Util.hs
@@ -54,7 +54,7 @@ retractPattern (TermAndPredicate patt) = Just patt
 retractPattern _ = Nothing
 
 substituteInTerm :: Map Variable Term -> Term -> Term
-substituteInTerm substitution term = goSubst term
+substituteInTerm substitution = goSubst
   where
     goSubst t@(Term attributes tF)
         | Set.null attributes.variables = t

--- a/library/Kore/Pattern/Util.hs
+++ b/library/Kore/Pattern/Util.hs
@@ -54,9 +54,18 @@ retractPattern (TermAndPredicate patt) = Just patt
 retractPattern _ = Nothing
 
 substituteInTerm :: Map Variable Term -> Term -> Term
-substituteInTerm substitution = cata $ \case
-    VarF v -> fromMaybe (Var v) (Map.lookup v substitution)
-    other -> embed other
+substituteInTerm substitution term = goSubst term
+  where
+    goSubst t@(Term attributes tF)
+        | Set.null attributes.variables = t
+        | otherwise =
+            case tF of
+                VarF v ->
+                    fromMaybe t (Map.lookup v substitution)
+                DomainValueF{} -> t
+                SymbolApplicationF sym sorts args ->
+                    SymbolApplication sym sorts $ map goSubst args
+                AndTermF t1 t2 -> AndTerm (goSubst t1) (goSubst t2)
 
 substituteInPredicate :: Map Variable Term -> Predicate -> Predicate
 substituteInPredicate substitution = cata $ \case

--- a/library/Kore/Pattern/Util.hs
+++ b/library/Kore/Pattern/Util.hs
@@ -56,16 +56,14 @@ retractPattern _ = Nothing
 substituteInTerm :: Map Variable Term -> Term -> Term
 substituteInTerm substitution = goSubst
   where
-    goSubst t@(Term attributes tF)
-        | Set.null attributes.variables = t
-        | otherwise =
-            case tF of
-                VarF v ->
-                    fromMaybe t (Map.lookup v substitution)
-                DomainValueF{} -> t
-                SymbolApplicationF sym sorts args ->
-                    SymbolApplication sym sorts $ map goSubst args
-                AndTermF t1 t2 -> AndTerm (goSubst t1) (goSubst t2)
+    goSubst t
+        | Set.null (getAttributes t).variables = t
+        | otherwise = case t of
+            Var v -> fromMaybe t (Map.lookup v substitution)
+            DomainValue{} -> t
+            SymbolApplication sym sorts args ->
+                SymbolApplication sym sorts $ map goSubst args
+            AndTerm t1 t2 -> AndTerm (goSubst t1) (goSubst t2)
 
 substituteInPredicate :: Map Variable Term -> Predicate -> Predicate
 substituteInPredicate substitution = cata $ \case

--- a/package.yaml
+++ b/package.yaml
@@ -44,6 +44,9 @@ default-extensions:
   TypeFamilies
   ViewPatterns
 
+other-extensions:
+  TemplateHaskell
+
 ghc-options:
 - -Wall
 - -Wcompat
@@ -72,6 +75,7 @@ library:
   - exceptions
   - extra
   - filepath
+  - free
   - gitrev
   - hpp
   - json-rpc

--- a/package.yaml
+++ b/package.yaml
@@ -44,9 +44,6 @@ default-extensions:
   TypeFamilies
   ViewPatterns
 
-other-extensions:
-  TemplateHaskell
-
 ghc-options:
 - -Wall
 - -Wcompat
@@ -75,7 +72,6 @@ library:
   - exceptions
   - extra
   - filepath
-  - free
   - gitrev
   - hpp
   - json-rpc

--- a/test-suite/Test/Kore/Pattern/Rewrite.hs
+++ b/test-suite/Test/Kore/Pattern/Rewrite.hs
@@ -228,7 +228,7 @@ failsWith p err =
 ----------------------------------------
 -- tests for performRewrite (iterated rewrite in IO with logging)
 
-runRewrite :: Pattern -> IO (Natural, RewriteResult)
+runRewrite :: Pattern -> IO (Natural, RewriteResult Pattern)
 runRewrite = runNoLoggingT . performRewrite def Nothing Nothing [] []
 
 aborts :: Term -> IO ()
@@ -305,7 +305,7 @@ supportsDepthControl =
   where
     con1Term = termInKCell "C" $ app con1 [d]
     f1Term = termInKCell "C" $ app f1 [d]
-    runRewriteDepth :: Natural -> Pattern -> IO (Natural, RewriteResult)
+    runRewriteDepth :: Natural -> Pattern -> IO (Natural, RewriteResult Pattern)
     runRewriteDepth depth =
         runNoLoggingT . performRewrite def Nothing (Just depth) [] []
 
@@ -332,7 +332,7 @@ supportsCutPoints =
   where
     con1Term = termInKCell "C" $ app con1 [d]
     f1Term = termInKCell "C" $ app f1 [d]
-    runRewriteCutPoint :: Text -> Pattern -> IO (Natural, RewriteResult)
+    runRewriteCutPoint :: Text -> Pattern -> IO (Natural, RewriteResult Pattern)
     runRewriteCutPoint lbl =
         runNoLoggingT . performRewrite def Nothing Nothing [lbl] []
 
@@ -350,6 +350,6 @@ supportsTerminalRules =
   where
     con1Term = termInKCell "C" $ app con1 [d]
     f1Term = termInKCell "C" $ app f1 [d]
-    runRewriteTerminal :: Text -> Pattern -> IO (Natural, RewriteResult)
+    runRewriteTerminal :: Text -> Pattern -> IO (Natural, RewriteResult Pattern)
     runRewriteTerminal lbl =
         runNoLoggingT . performRewrite def Nothing Nothing [] [lbl]

--- a/test-suite/Test/Kore/Pattern/Rewrite.hs
+++ b/test-suite/Test/Kore/Pattern/Rewrite.hs
@@ -204,7 +204,7 @@ definednessUnclear =
 rewriteStuck =
     testCase "con3 app is stuck (no rules apply)" $ do
         let con3App = termInKCell "ConfigVar" $ app con3 [d, d]
-        runRewriteM def Nothing (rewriteStep [] [] con3App) @?= Right (RewriteStuck con3App)
+        runRewriteM def Nothing (rewriteStep [] [] con3App) @?= Left NoApplicableRules
 rulePriority =
     testCase "con1 rewrites to a branch when higher priority does not apply" $ do
         let d2 = dv someSort "otherThing"
@@ -261,8 +261,8 @@ abortsOnErrors =
     testGroup
         "Aborts rewrite when there is an error"
         [ testCase "when there are no rules at all" $ aborts (app con2 [d])
-        --        , testCase "when the term index is None" $
-        --              aborts (AndTerm (app con1 [d]) (app con2 [d]))
+        , testCase "when the term index is None" $
+            aborts (AndTerm (app con1 [d]) (app con2 [d]))
         ]
 
 callsError :: TestTree


### PR DESCRIPTION
We only call the LLVM simplification when rewriting cannot proceed (stuck or unification unclear), and before we return the result to the caller.
This speeds up the `IMP` execution quite a bit (together with an optimisation using the attributes in the substitution routine).

Includes runtimeverification/hs-backend-booster#100 
Fixes runtimeverification/hs-backend-booster#88 
Fixes runtimeverification/hs-backend-booster#101 