### PR TITLE
Make rpc-client shutdown the socket when things went fine

### DIFF
--- a/tools/rpc-client/RpcClient.hs
+++ b/tools/rpc-client/RpcClient.hs
@@ -27,6 +27,7 @@ import Data.Maybe (isNothing)
 import Data.Text qualified as Text
 import Data.Vector as Array (fromList)
 import Network.Run.TCP
+import Network.Socket
 import Network.Socket.ByteString.Lazy
 import Options.Applicative
 import System.Clock
@@ -62,6 +63,7 @@ main = do
 
         trace "[Info] Response received." $
             postProcess prettify postProcessing response
+        shutdown s ShutdownBoth
   where
     readResponse s bufSize = do
         part <- recv s bufSize


### PR DESCRIPTION
This re-enables measuring time with `time rpc-client` instead of using the internal time measurement