### PR TITLE
Allow log levels > Info to be selected

### DIFF
--- a/library/Server.hs
+++ b/library/Server.hs
@@ -128,7 +128,7 @@ adjustLogLevels :: [LogLevel] -> (LogLevel, [LogLevel])
 adjustLogLevels ls = (standardLevel, customLevels)
   where
     (stds, customLevels) = partition (<= LevelError) ls
-    standardLevel = minimum (LevelInfo : stds)
+    standardLevel = if null stds then LevelInfo else minimum stds
 
 versionInfoStr :: String
 versionInfoStr =


### PR DESCRIPTION
The prior code silently raised all log levels to at least Info  level, causing requests to be printed in full by the json-rpc library.