### PR TITLE
Avoid traversing irrelevant config in `substituteInTerm`

### DIFF
--- a/library/Kore/Pattern/Util.hs
+++ b/library/Kore/Pattern/Util.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS -fno-warn-unrecognised-pragmas #-}
+
 {- |
 Copyright   : (c) Runtime Verification, 2022
 License     : BSD-3-Clause


### PR DESCRIPTION
`substituteInTerm` was traversing all parts of the term that contains variables, regardless of what it was actually substituting. The change avoids traversal when the contained variables are not the substituted ones. This matters for large configurations like the KEVM one, but did not show in the IMP examples.

Had to use an ignore pragma for hlint because of [an hlint bug with `OverloadedRecordDot`](https://github.com/ndmitchell/hlint/issues/1458)