### PR TITLE
Print equation trace in case of a loop, tweak tracing code

### DIFF
--- a/unit-tests/Test/Booster/Pattern/ApplyEquations.hs
+++ b/unit-tests/Test/Booster/Pattern/ApplyEquations.hs
@@ -102,11 +102,14 @@ test_errors =
             let a = var "A" someSort
                 f = app f1 . (: [])
                 subj = f $ app con1 [a]
-                result =
-                    EquationLoop
-                        [f $ app con1 [a], f $ app con2 [a], f $ app con3 [a, a], f $ app con1 [a]]
-            evaluateTerm TopDown loopDef Nothing subj @?= Left result
+                loopTerms =
+                    [f $ app con1 [a], f $ app con2 [a], f $ app con3 [a, a], f $ app con1 [a]]
+            isLoop loopTerms $ evaluateTerm TopDown loopDef Nothing subj
         ]
+  where
+    isLoop ts (Left (EquationLoop _ ts')) = ts @?= ts'
+    isLoop _ (Left err) = assertFailure $ "Unexpected error " <> show err
+    isLoop _ (Right r) = assertFailure $ "Unexpected result " <> show r
 
 ----------------------------------------
 


### PR DESCRIPTION
Previously we would not get the information about what simplifications were performed when a loop was detected.
Also tweaked the code to use a dedicated type and a `Pretty` instance.

This does not conflict with #162 . Work done while tracking down an evaluation loop, see #164)