### PR TITLE
Switch to public cachix cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,7 +164,7 @@ jobs:
 
       - name: Build executables
         env:
-          CACHIX_AUTH_TOKEN: '${{ secrets.CACHIX_PRIVATE_TOKEN }}'
+          CACHIX_AUTH_TOKEN: '${{ secrets.CACHIX_PUBLIC_TOKEN }}'
           NIX_PATH: 'nixpkgs=http://nixos.org/channels/nixos-22.05/nixexprs.tar.xz'
           GC_DONT_GC: '1'
         run: |
@@ -172,7 +172,7 @@ jobs:
           export JQ=$(nix-build '<nixpkgs>' -A jq --no-link)/bin/jq
           booster=$(nix build .#hs-backend-booster:exe:booster --extra-experimental-features 'nix-command flakes' --print-build-logs --json | $JQ -r '.[].outputs | to_entries[].value')
           drv=$(nix-store --query --deriver ${booster})
-          nix-store --query --requisites --include-outputs ${drv} | cachix push runtimeverification
+          nix-store --query --requisites --include-outputs ${drv} | cachix push k-framework
           nix build .#hs-backend-booster:exe:parsetest --extra-experimental-features 'nix-command flakes' --print-build-logs
           nix build .#hs-backend-booster:exe:rpc-client --extra-experimental-features 'nix-command flakes' --print-build-logs
 


### PR DESCRIPTION
As this project is now open source, switching to use the public `k-framework.cachix.org` cache.