### PR TITLE
199 pass `get-model` through to kore-rpc

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -200,7 +200,8 @@ jobs:
       - name: Run unit tests
         env:
           GC_DONT_GC: '1'
-        run: nix build .#checks.unit-tests --extra-experimental-features 'nix-command flakes' --print-build-logs
+        run: nix build .#hs-backend-booster:test:unit-tests --extra-experimental-features 'nix-command flakes' --print-build-logs
+
 
       - name: Run integration tests
         if: ${{ matrix.os != 'macos-12' }}  ## takes long on public runner, already tested in MacM1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -215,5 +215,7 @@ jobs:
           nix build .#checks.${{ matrix.nix }}.integration.module-addition --extra-experimental-features 'nix-command flakes' --print-build-logs
           nix build .#checks.${{ matrix.nix }}.integration.imp --extra-experimental-features 'nix-command flakes' --print-build-logs -o imp.md
           nix build .#checks.${{ matrix.nix }}.integration.existentials --extra-experimental-features 'nix-command flakes' --print-build-logs
+          nix build .#checks.${{ matrix.nix }}.integration.simplify --extra-experimental-features 'nix-command flakes' --print-build-logs
+          nix build .#checks.${{ matrix.nix }}.integration.get-model --extra-experimental-features 'nix-command flakes' --print-build-logs
           echo "${{ matrix.nix }}" >> $GITHUB_STEP_SUMMARY
           cat imp.md >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -200,7 +200,7 @@ jobs:
       - name: Run unit tests
         env:
           GC_DONT_GC: '1'
-        run: nix build .#hs-backend-booster:test:unit-tests --extra-experimental-features 'nix-command flakes' --print-build-logs
+        run: nix run .#hs-backend-booster:test:unit-tests --extra-experimental-features 'nix-command flakes' --print-build-logs
 
 
       - name: Run integration tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -200,8 +200,7 @@ jobs:
       - name: Run unit tests
         env:
           GC_DONT_GC: '1'
-        run: nix build .#hs-backend-booster:test:unit-tests --extra-experimental-features 'nix-command flakes' --print-build-logs
-
+        run: nix build .#checks.unit-tests --extra-experimental-features 'nix-command flakes' --print-build-logs
 
       - name: Run integration tests
         if: ${{ matrix.os != 'macos-12' }}  ## takes long on public runner, already tested in MacM1

--- a/cabal.project
+++ b/cabal.project
@@ -15,6 +15,6 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/runtimeverification/haskell-backend.git
-    tag: 740a60ee231ad63b811f0ca023cbf747ae0aa82d
-    --sha256: sha256-L/jJRyX0lqwaEG9NJU52DIvKXUHIOoGJ7Bw/yK9eehA=
+    tag: 06c9515d802093b7e3267e2d3e7460f4a2cf8ede
+    --sha256: sha256-YP210TMB3iSCsYNeIjoijJfVAEPOI9JG4PM2irkV8Wk=
     subdir: kore kore-rpc-types

--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
         "z3-src": "z3-src"
       },
       "locked": {
-        "lastModified": 1686826973,
-        "narHash": "sha256-B6LOJU+j8rcOuXg84HVCm140z+BsWmqwUOMHG6mmaMk=",
+        "lastModified": 1687174698,
+        "narHash": "sha256-+sKUmVh88rgWqcrZXgfKbreeLOCQ7MxsXbw67oDt86M=",
         "owner": "runtimeverification",
         "repo": "haskell-backend",
-        "rev": "d60d91d3a845be1848e028458317ef675ac4af72",
+        "rev": "06c9515d802093b7e3267e2d3e7460f4a2cf8ede",
         "type": "github"
       },
       "original": {

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,7 +12,7 @@ extra-deps:
   - typerep-map-0.6.0.0
   - monad-validate-1.2.0.0@sha256:9850f408431098b28806dd464b6825a88a0b56c84f380d7fe0454c1df9d6f881,3505
   - git: https://github.com/runtimeverification/haskell-backend.git
-    commit: 740a60ee231ad63b811f0ca023cbf747ae0aa82d
+    commit: 06c9515d802093b7e3267e2d3e7460f4a2cf8ede
     subdirs:
       - kore
       - kore-rpc-types

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -47,29 +47,29 @@ packages:
   original:
     hackage: monad-validate-1.2.0.0@sha256:9850f408431098b28806dd464b6825a88a0b56c84f380d7fe0454c1df9d6f881,3505
 - completed:
-    commit: 740a60ee231ad63b811f0ca023cbf747ae0aa82d
+    commit: 06c9515d802093b7e3267e2d3e7460f4a2cf8ede
     git: https://github.com/runtimeverification/haskell-backend.git
     name: kore
     pantry-tree:
-      sha256: e5b065a72b8d6387d75abccc8f046260f32768d307a87a3375b1ee55461ac36b
+      sha256: c99eb2e1e674f6da0c9c9e64735c220787efcda5ecca4c0bdd00fc62f82d7274
       size: 44478
     subdir: kore
     version: 0.60.0.0
   original:
-    commit: 740a60ee231ad63b811f0ca023cbf747ae0aa82d
+    commit: 06c9515d802093b7e3267e2d3e7460f4a2cf8ede
     git: https://github.com/runtimeverification/haskell-backend.git
     subdir: kore
 - completed:
-    commit: 740a60ee231ad63b811f0ca023cbf747ae0aa82d
+    commit: 06c9515d802093b7e3267e2d3e7460f4a2cf8ede
     git: https://github.com/runtimeverification/haskell-backend.git
     name: kore-rpc-types
     pantry-tree:
-      sha256: b767a4729e7eafacf66b9e1ed598391b572c5f843ca8c2b84df5474e60deb6b8
+      sha256: dd3ceace4dc6a415ac97890808e12bb8d462a81e15f8a192dfeb920c978318fc
       size: 404
     subdir: kore-rpc-types
     version: 0.60.0.0
   original:
-    commit: 740a60ee231ad63b811f0ca023cbf747ae0aa82d
+    commit: 06c9515d802093b7e3267e2d3e7460f4a2cf8ede
     git: https://github.com/runtimeverification/haskell-backend.git
     subdir: kore-rpc-types
 snapshots:

--- a/test/rpc-integration/default.nix
+++ b/test/rpc-integration/default.nix
@@ -44,4 +44,5 @@ in {
   existentials = mkIntegrationTest { name = "existentials"; };
   module-addition = mkIntegrationTest { name = "module-addition"; };
   simplify = mkIntegrationTest { name = "simplify"; };
+  get-model = mkIntegrationTest { name = "get-model"; };
 }

--- a/test/rpc-integration/resources/get-model.kore
+++ b/test/rpc-integration/resources/get-model.kore
@@ -1,0 +1,1 @@
+int-and-bool.kore

--- a/test/rpc-integration/resources/int-and-bool.k
+++ b/test/rpc-integration/resources/int-and-bool.k
@@ -1,0 +1,5 @@
+module TEST
+  imports INT
+  imports BOOL
+
+endmodule

--- a/test/rpc-integration/resources/int-and-bool.kore
+++ b/test/rpc-integration/resources/int-and-bool.kore
@@ -1,0 +1,2727 @@
+[topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(int-and-bool.k)")]
+
+module BASIC-K
+    sort SortK{} []
+    sort SortKItem{} []
+endmodule
+[]
+module KSEQ
+    import BASIC-K []
+    symbol kseq{}(SortKItem{}, SortK{}) : SortK{} [constructor{}(), functional{}(), injective{}()]
+    symbol dotk{}() : SortK{} [constructor{}(), functional{}(), injective{}()]
+    symbol append{}(SortK{}, SortK{}) : SortK{} [function{}(), functional{}()]
+    axiom {R} \implies{R}(
+        \and{R}(
+            \top{R}(),
+            \and{R}(
+                \in{SortK{}, R}(X0:SortK{}, dotk{}()),
+            \and{R}(
+                \in{SortK{}, R}(X1:SortK{}, TAIL:SortK{}),
+                \top{R}()
+            ))
+        ),
+        \equals{SortK{}, R}(
+            append{}(X0:SortK{}, X1:SortK{}),
+            \and{SortK{}}(
+                TAIL:SortK{},
+                \top{SortK{}}()
+            )
+        )
+    ) []
+    axiom {R} \implies{R}(
+        \and{R}(
+            \top{R}(),
+            \and{R}(
+                \in{SortK{}, R}(X0:SortK{}, kseq{}(K:SortKItem{}, KS:SortK{})),
+            \and{R}(
+                \in{SortK{}, R}(X1:SortK{}, TAIL:SortK{}),
+                \top{R}()
+            ))
+        ),
+        \equals{SortK{}, R}(
+            append{}(X0:SortK{}, X1:SortK{}),
+            \and{SortK{}}(
+                kseq{}(K:SortKItem{}, append{}(KS:SortK{}, TAIL:SortK{})),
+                \top{SortK{}}()
+            )
+        )
+    ) []
+endmodule
+[]
+module INJ
+    symbol inj{From, To}(From) : To [sortInjection{}()]
+    axiom {S1, S2, S3, R} \equals{S3, R}(inj{S2, S3}(inj{S1, S2}(T:S1)), inj{S1, S3}(T:S1)) [simplification{}()]
+endmodule
+[]
+module K
+    import KSEQ []
+    import INJ []
+    alias weakExistsFinally{A}(A) : A where weakExistsFinally{A}(@X:A) := @X:A []
+    alias weakAlwaysFinally{A}(A) : A where weakAlwaysFinally{A}(@X:A) := @X:A []
+    alias allPathGlobally{A}(A) : A where allPathGlobally{A}(@X:A) := @X:A []
+endmodule
+[]
+
+module TEST
+
+// imports
+  import K []
+
+// sorts
+  sort SortKCellOpt{} []
+  sort SortGeneratedTopCellFragment{} []
+  hooked-sort SortList{} [concat{}(Lbl'Unds'List'Unds'{}()), element{}(LblListItem{}()), hook{}("LIST.List"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(913,3,913,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), unit{}(Lbl'Stop'List{}())]
+  sort SortKCell{} []
+  sort SortGeneratedTopCell{} []
+  sort SortGeneratedCounterCell{} []
+  hooked-sort SortMap{} [concat{}(Lbl'Unds'Map'Unds'{}()), element{}(Lbl'UndsPipe'-'-GT-Unds'{}()), hook{}("MAP.Map"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(218,3,218,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), unit{}(Lbl'Stop'Map{}())]
+  sort SortGeneratedCounterCellOpt{} []
+  sort SortKConfigVar{} [hasDomainValues{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(40,3,40,28)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/kast.md)"), token{}()]
+  hooked-sort SortInt{} [hasDomainValues{}(), hook{}("INT.Int"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1189,3,1189,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)")]
+  hooked-sort SortSet{} [concat{}(Lbl'Unds'Set'Unds'{}()), element{}(LblSetItem{}()), hook{}("SET.Set"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(700,3,700,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), unit{}(Lbl'Stop'Set{}())]
+  hooked-sort SortBool{} [hasDomainValues{}(), hook{}("BOOL.Bool"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1068,3,1068,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)")]
+
+// symbols
+  hooked-symbol Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL-SYNTAX'Unds'Sort'Unds'Bool'Unds'Sort'Unds'Sort{SortSort}(SortBool{}, SortSort, SortSort) : SortSort [format{}("%c#if%r %1 %c#then%r %2 %c#else%r %3 %c#fi%r"), function{}(), functional{}(), hook{}("KEQUAL.ite"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2264,26,2264,121)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("ite"), terminals{}("1010101"), total{}()]
+  hooked-symbol Lbl'Stop'List{}() : SortList{} [format{}("%c.List%r"), function{}(), functional{}(), hook{}("LIST.unit"), klabel{}(".List"), latex{}("\\dotCt{List}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(937,19,937,142)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smtlib{}("smt_seq_nil"), symbol'Kywd'{}(), terminals{}("1"), total{}()]
+  hooked-symbol Lbl'Stop'Map{}() : SortMap{} [format{}("%c.Map%r"), function{}(), functional{}(), hook{}("MAP.unit"), klabel{}(".Map"), latex{}("\\dotCt{Map}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(248,18,248,124)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1"), total{}()]
+  hooked-symbol Lbl'Stop'Set{}() : SortSet{} [format{}("%c.Set%r"), function{}(), functional{}(), hook{}("SET.unit"), klabel{}(".Set"), latex{}("\\dotCt{Set}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(729,18,729,118)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1"), total{}()]
+  symbol Lbl'-LT-'generatedCounter'-GT-'{}(SortInt{}) : SortGeneratedCounterCell{} [cell{}(), cellName{}("generatedCounter"), constructor{}(), format{}("%c<generatedCounter>%r%i%n%1%d%n%c</generatedCounter>%r"), functional{}(), injective{}(), left{}(), priorities{}(), right{}(), terminals{}("101")]
+  symbol Lbl'-LT-'generatedTop'-GT-'{}(SortKCell{}, SortGeneratedCounterCell{}) : SortGeneratedTopCell{} [cell{}(), cellName{}("generatedTop"), constructor{}(), format{}("%1"), functional{}(), injective{}(), left{}(), priorities{}(), right{}(), terminals{}("1001"), topcell{}()]
+  symbol Lbl'-LT-'generatedTop'-GT-'-fragment{}(SortKCellOpt{}, SortGeneratedCounterCellOpt{}) : SortGeneratedTopCellFragment{} [cellFragment{}("GeneratedTopCell"), constructor{}(), format{}("%c<generatedTop>-fragment%r %1 %2 %c</generatedTop>-fragment%r"), functional{}(), injective{}(), left{}(), priorities{}(), right{}(), terminals{}("1001")]
+  symbol Lbl'-LT-'k'-GT-'{}(SortK{}) : SortKCell{} [cell{}(), cellName{}("k"), constructor{}(), format{}("%c<k>%r%i%n%1%d%n%c</k>%r"), functional{}(), injective{}(), left{}(), maincell{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(535,17,535,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/kast.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), priorities{}(), right{}(), terminals{}("101"), topcell{}()]
+  hooked-symbol LblList'Coln'get{}(SortList{}, SortInt{}) : SortKItem{} [format{}("%1 %c[%r %2 %c]%r"), function{}(), hook{}("LIST.get"), klabel{}("List:get"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(956,20,956,99)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("0101")]
+  hooked-symbol LblList'Coln'range{}(SortList{}, SortInt{}, SortInt{}) : SortList{} [format{}("%crange%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}(), hook{}("LIST.range"), klabel{}("List:range"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1003,19,1003,120)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("11010101")]
+  hooked-symbol LblListItem{}(SortKItem{}) : SortList{} [format{}("%cListItem%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("LIST.element"), klabel{}("ListItem"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(945,19,945,132)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smtlib{}("smt_seq_elem"), symbol'Kywd'{}(), terminals{}("1101"), total{}()]
+  hooked-symbol LblMap'Coln'lookup{}(SortMap{}, SortKItem{}) : SortKItem{} [format{}("%1 %c[%r %2 %c]%r"), function{}(), hook{}("MAP.lookup"), klabel{}("Map:lookup"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(271,20,271,113)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("0101")]
+  hooked-symbol LblMap'Coln'update{}(SortMap{}, SortKItem{}, SortKItem{}) : SortMap{} [format{}("%1 %c[%r %2 %c<-%r %3 %c]%r"), function{}(), functional{}(), hook{}("MAP.update"), klabel{}("Map:update"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(290,18,290,140)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), prefer{}(), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("010101"), total{}()]
+  hooked-symbol LblSet'Coln'difference{}(SortSet{}, SortSet{}) : SortSet{} [format{}("%1 %c-Set%r %2"), function{}(), functional{}(), hook{}("SET.difference"), klabel{}("Set:difference"), latex{}("{#1}-_{\\it Set}{#2}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(769,18,769,142)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol LblSet'Coln'in{}(SortKItem{}, SortSet{}) : SortBool{} [format{}("%1 %cin%r %2"), function{}(), functional{}(), hook{}("SET.in"), klabel{}("Set:in"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(777,19,777,102)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol LblSetItem{}(SortKItem{}) : SortSet{} [format{}("%cSetItem%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("SET.element"), injective{}(), klabel{}("SetItem"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(737,18,737,119)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1101"), total{}()]
+  hooked-symbol Lbl'UndsPerc'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%1 %c%%Int%r %2"), function{}(), hook{}("INT.tmod"), klabel{}("_%Int_"), latex{}("{#1}\\mathrel{\\%_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'UndsStar'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1237,18,1237,171)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), right{}(), smt-hook{}("mod"), symbol'Kywd'{}(), terminals{}("010")]
+  hooked-symbol Lbl'UndsAnd-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [comm{}(), format{}("%1 %c&Int%r %2"), function{}(), functional{}(), hook{}("INT.and"), klabel{}("_&Int_"), latex{}("{#1}\\mathrel{\\&_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'UndsAnd-'Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1248,18,1248,184)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), right{}(), smtlib{}("andInt"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsStar'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [comm{}(), format{}("%1 %c*Int%r %2"), function{}(), functional{}(), hook{}("INT.mul"), klabel{}("_*Int_"), latex{}("{#1}\\mathrel{\\ast_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'Unds'modInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsStar'Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1233,18,1233,183)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), right{}(), smt-hook{}("*"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsPlus'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [comm{}(), format{}("%1 %c+Int%r %2"), function{}(), functional{}(), hook{}("INT.add"), klabel{}("_+Int_"), latex{}("{#1}\\mathrel{+_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1242,18,1242,180)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), right{}(), smt-hook{}("+"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'-Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%1 %c-Int%r %2"), function{}(), functional{}(), hook{}("INT.sub"), klabel{}("_-Int_"), latex{}("{#1}\\mathrel{-_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1243,18,1243,174)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), right{}(), smt-hook{}("-"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'-Map'UndsUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortMap{} [format{}("%1 %c-Map%r %2"), function{}(), functional{}(), hook{}("MAP.difference"), latex{}("{#1}-_{\\it Map}{#2}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(311,18,311,116)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsSlsh'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%1 %c/Int%r %2"), function{}(), hook{}("INT.tdiv"), klabel{}("_/Int_"), latex{}("{#1}\\mathrel{\\div_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'UndsStar'Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1236,18,1236,173)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), right{}(), smt-hook{}("div"), symbol'Kywd'{}(), terminals{}("010")]
+  hooked-symbol Lbl'Unds-LT--LT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%1 %c<<Int%r %2"), function{}(), hook{}("INT.shl"), klabel{}("_<<Int_"), latex{}("{#1}\\mathrel{\\ll_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1246,18,1246,173)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), right{}(), smtlib{}("shlInt"), symbol'Kywd'{}(), terminals{}("010")]
+  hooked-symbol Lbl'Unds-LT-Eqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [format{}("%1 %c<=Int%r %2"), function{}(), functional{}(), hook{}("INT.le"), klabel{}("_<=Int_"), latex{}("{#1}\\mathrel{\\leq_{\\scriptstyle\\it Int}}{#2}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1304,19,1304,166)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("<="), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'Map'UndsUnds'MAP'Unds'Bool'Unds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortBool{} [format{}("%1 %c<=Map%r %2"), function{}(), functional{}(), hook{}("MAP.inclusion"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(383,19,383,87)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'Set'UndsUnds'SET'Unds'Bool'Unds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortBool{} [format{}("%1 %c<=Set%r %2"), function{}(), functional{}(), hook{}("SET.inclusion"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(786,19,786,81)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds-LT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [format{}("%1 %c<Int%r %2"), function{}(), functional{}(), hook{}("INT.lt"), klabel{}("_<Int_"), latex{}("{#1}\\mathrel{<_{\\scriptstyle\\it Int}}{#2}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1305,19,1305,161)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("<"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [comm{}(), format{}("%1 %c=/=Bool%r %2"), function{}(), functional{}(), hook{}("BOOL.ne"), klabel{}("_=/=Bool_"), left{}(Lbl'UndsEqlsEqls'Bool'Unds'{}(),Lbl'UndsEqlsSlshEqls'Bool'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1109,19,1109,134)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("distinct"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [comm{}(), format{}("%1 %c=/=Int%r %2"), function{}(), functional{}(), hook{}("INT.ne"), klabel{}("_=/=Int_"), latex{}("{#1}\\mathrel{{=}{/}{=}_{\\scriptstyle\\it Int}}{#2}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1309,19,1309,184)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("distinct"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [comm{}(), format{}("%1 %c=/=K%r %2"), function{}(), functional{}(), hook{}("KEQUAL.ne"), klabel{}("_=/=K_"), latex{}("{#1}\\mathrel{\\neq_K}{#2}"), left{}(Lbl'UndsEqlsEqls'K'Unds'{}(),Lbl'UndsEqlsSlshEqls'K'Unds'{}()), notEqualEqualK{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2260,19,2260,179)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(Lbl'Unds'orElseBool'Unds'{}(),Lbl'Unds'orBool'Unds'{}(),Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'Unds'andThenBool'Unds'{}(),Lbl'Unds'impliesBool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}(),Lbl'Unds'andBool'Unds'{}(),LblnotBool'Unds'{}(),Lbl'Unds'xorBool'Unds'{}()), right{}(), smt-hook{}("distinct"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'Bool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [comm{}(), format{}("%1 %c==Bool%r %2"), function{}(), functional{}(), hook{}("BOOL.eq"), klabel{}("_==Bool_"), left{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1108,19,1108,126)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("="), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [comm{}(), format{}("%1 %c==Int%r %2"), function{}(), functional{}(), hook{}("INT.eq"), klabel{}("_==Int_"), latex{}("{#1}\\mathrel{{=}{=}_{\\scriptstyle\\it Int}}{#2}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1308,19,1308,173)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("="), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [comm{}(), equalEqualK{}(), format{}("%1 %c==K%r %2"), function{}(), functional{}(), hook{}("KEQUAL.eq"), klabel{}("_==K_"), latex{}("{#1}\\mathrel{=_K}{#2}"), left{}(Lbl'UndsEqlsSlshEqls'K'Unds'{}(),Lbl'UndsEqlsEqls'K'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2259,19,2259,165)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(Lbl'Unds'orElseBool'Unds'{}(),Lbl'Unds'orBool'Unds'{}(),Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'Unds'andThenBool'Unds'{}(),Lbl'Unds'impliesBool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}(),Lbl'Unds'andBool'Unds'{}(),LblnotBool'Unds'{}(),Lbl'Unds'xorBool'Unds'{}()), right{}(), smt-hook{}("="), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds-GT-Eqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [format{}("%1 %c>=Int%r %2"), function{}(), functional{}(), hook{}("INT.ge"), klabel{}("_>=Int_"), latex{}("{#1}\\mathrel{\\geq_{\\scriptstyle\\it Int}}{#2}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1306,19,1306,166)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}(">="), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds-GT--GT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%1 %c>>Int%r %2"), function{}(), hook{}("INT.shr"), klabel{}("_>>Int_"), latex{}("{#1}\\mathrel{\\gg_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1245,18,1245,173)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), right{}(), smtlib{}("shrInt"), symbol'Kywd'{}(), terminals{}("010")]
+  hooked-symbol Lbl'Unds-GT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [format{}("%1 %c>Int%r %2"), function{}(), functional{}(), hook{}("INT.gt"), klabel{}("_>Int_"), latex{}("{#1}\\mathrel{>_{\\scriptstyle\\it Int}}{#2}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1307,19,1307,161)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}(">"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'List'Unds'{}(SortList{}, SortList{}) : SortList{} [assoc{}(), element{}(LblListItem{}()), format{}("%1%n%2"), function{}(), functional{}(), hook{}("LIST.concat"), klabel{}("_List_"), left{}(Lbl'Unds'List'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(929,19,929,188)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smtlib{}("smt_seq_concat"), symbol'Kywd'{}(), terminals{}("00"), total{}(), unit{}(Lbl'Stop'List{}())]
+  hooked-symbol Lbl'Unds'Map'Unds'{}(SortMap{}, SortMap{}) : SortMap{} [assoc{}(), comm{}(), element{}(Lbl'UndsPipe'-'-GT-Unds'{}()), format{}("%1%n%2"), function{}(), hook{}("MAP.concat"), index{}("0"), klabel{}("_Map_"), left{}(Lbl'Unds'Map'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(240,18,240,173)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("00"), unit{}(Lbl'Stop'Map{}())]
+  hooked-symbol Lbl'Unds'Set'Unds'{}(SortSet{}, SortSet{}) : SortSet{} [assoc{}(), comm{}(), element{}(LblSetItem{}()), format{}("%1%n%2"), function{}(), hook{}("SET.concat"), idem{}(), klabel{}("_Set_"), left{}(Lbl'Unds'Set'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(721,18,721,165)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("00"), unit{}(Lbl'Stop'Set{}())]
+  hooked-symbol Lbl'UndsLSqBUnds-LT-'-'UndsRSqBUnds'LIST'Unds'List'Unds'List'Unds'Int'Unds'KItem{}(SortList{}, SortInt{}, SortKItem{}) : SortList{} [format{}("%1 %c[%r %2 %c<-%r %3 %c]%r"), function{}(), hook{}("LIST.update"), klabel{}("List:set"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(965,19,965,108)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010101")]
+  hooked-symbol Lbl'UndsLSqBUnds-LT-'-undef'RSqB'{}(SortMap{}, SortKItem{}) : SortMap{} [format{}("%1 %c[%r %2 %c<-%r %cundef%r %c]%r"), function{}(), functional{}(), hook{}("MAP.remove"), klabel{}("_[_<-undef]"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(299,18,299,117)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("010111"), total{}()]
+  hooked-symbol Lbl'UndsLSqBUndsRSqB'orDefault'UndsUnds'MAP'Unds'KItem'Unds'Map'Unds'KItem'Unds'KItem{}(SortMap{}, SortKItem{}, SortKItem{}) : SortKItem{} [format{}("%1 %c[%r %2 %c]%r %corDefault%r %3"), function{}(), functional{}(), hook{}("MAP.lookupOrDefault"), klabel{}("Map:lookupOrDefault"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(281,20,281,134)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010110"), total{}()]
+  hooked-symbol Lbl'UndsXor-Perc'Int'UndsUnds'{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [format{}("%1 %c^%%Int%r %2 %3"), function{}(), hook{}("INT.powmod"), klabel{}("_^%Int__"), left{}(Lbl'UndsXor-Perc'Int'UndsUnds'{}(),Lbl'UndsXor-'Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1231,18,1231,139)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), right{}(), smt-hook{}("(mod (^ #1 #2) #3)"), symbol'Kywd'{}(), terminals{}("0100")]
+  hooked-symbol Lbl'UndsXor-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%1 %c^Int%r %2"), function{}(), hook{}("INT.pow"), klabel{}("_^Int_"), latex{}("{#1}\\mathrel{{\\char`\\^}_{\\!\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'UndsXor-'Int'Unds'{}(),Lbl'UndsXor-Perc'Int'UndsUnds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1230,18,1230,178)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), right{}(), smt-hook{}("^"), symbol'Kywd'{}(), terminals{}("010")]
+  hooked-symbol Lbl'Unds'andBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [boolOperation{}(), format{}("%1 %candBool%r %2"), function{}(), functional{}(), hook{}("BOOL.and"), klabel{}("_andBool_"), latex{}("{#1}\\wedge_{\\scriptstyle\\it Bool}{#2}"), left{}(Lbl'Unds'andBool'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1101,19,1101,192)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), right{}(), smt-hook{}("and"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'andThenBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [boolOperation{}(), format{}("%1 %candThenBool%r %2"), function{}(), functional{}(), hook{}("BOOL.andThen"), klabel{}("_andThenBool_"), left{}(Lbl'Unds'andThenBool'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1102,19,1102,154)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), right{}(), smt-hook{}("and"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'divInt'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%1 %cdivInt%r %2"), function{}(), hook{}("INT.ediv"), klabel{}("_divInt_"), left{}(Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1239,18,1239,122)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), right{}(), smt-hook{}("div"), symbol'Kywd'{}(), terminals{}("010")]
+  symbol Lbl'Unds'dividesInt'UndsUnds'INT-COMMON'Unds'Bool'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [format{}("%1 %cdividesInt%r %2"), function{}(), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1318,19,1318,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010")]
+  hooked-symbol Lbl'Unds'impliesBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [boolOperation{}(), format{}("%1 %cimpliesBool%r %2"), function{}(), functional{}(), hook{}("BOOL.implies"), klabel{}("_impliesBool_"), left{}(Lbl'Unds'impliesBool'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1106,19,1106,153)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), right{}(), smt-hook{}("=>"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'in'UndsUnds'LIST'Unds'Bool'Unds'KItem'Unds'List{}(SortKItem{}, SortList{}) : SortBool{} [format{}("%1 %cin%r %2"), function{}(), functional{}(), hook{}("LIST.in"), klabel{}("_inList_"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1012,19,1012,97)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'Unds'Bool'Unds'KItem'Unds'Map{}(SortKItem{}, SortMap{}) : SortBool{} [format{}("%1 %cin_keys%r %c(%r %2 %c)%r"), function{}(), functional{}(), hook{}("MAP.in_keys"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(357,19,357,89)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("01101"), total{}()]
+  hooked-symbol Lbl'Unds'modInt'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%1 %cmodInt%r %2"), function{}(), hook{}("INT.emod"), klabel{}("_modInt_"), left{}(Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1240,18,1240,122)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), right{}(), smt-hook{}("mod"), symbol'Kywd'{}(), terminals{}("010")]
+  hooked-symbol Lbl'Unds'orBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [boolOperation{}(), format{}("%1 %corBool%r %2"), function{}(), functional{}(), hook{}("BOOL.or"), klabel{}("_orBool_"), latex{}("{#1}\\vee_{\\scriptstyle\\it Bool}{#2}"), left{}(Lbl'Unds'orBool'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1104,19,1104,187)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), right{}(), smt-hook{}("or"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'orElseBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [boolOperation{}(), format{}("%1 %corElseBool%r %2"), function{}(), functional{}(), hook{}("BOOL.orElse"), klabel{}("_orElseBool_"), left{}(Lbl'Unds'orElseBool'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1105,19,1105,151)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), right{}(), smt-hook{}("or"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'xorBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [boolOperation{}(), format{}("%1 %cxorBool%r %2"), function{}(), functional{}(), hook{}("BOOL.xor"), klabel{}("_xorBool_"), left{}(Lbl'Unds'xorBool'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1103,19,1103,146)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), right{}(), smt-hook{}("xor"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'xorInt'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [comm{}(), format{}("%1 %cxorInt%r %2"), function{}(), functional{}(), hook{}("INT.xor"), klabel{}("_xorInt_"), latex{}("{#1}\\mathrel{\\oplus_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'Unds'xorInt'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1250,18,1250,190)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsPipe'Int'Unds'{}()), right{}(), smtlib{}("xorInt"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsPipe'-'-GT-Unds'{}(SortKItem{}, SortKItem{}) : SortMap{} [format{}("%1 %c|->%r %2"), function{}(), functional{}(), hook{}("MAP.element"), injective{}(), klabel{}("_|->_"), latex{}("{#1}\\mapsto{#2}"), left{}(Lbl'UndsPipe'-'-GT-Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(257,18,257,151)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(Lbl'Stop'Map{}(),Lbl'Unds'Map'Unds'{}()), right{}(Lbl'UndsPipe'-'-GT-Unds'{}()), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsPipe'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [comm{}(), format{}("%1 %c|Int%r %2"), function{}(), functional{}(), hook{}("INT.or"), klabel{}("_|Int_"), latex{}("{#1}\\mathrel{|_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'UndsPipe'Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1252,18,1252,181)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smtlib{}("orInt"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortSet{} [comm{}(), format{}("%1 %c|Set%r %2"), function{}(), functional{}(), hook{}("SET.union"), left{}(Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(748,18,748,92)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), total{}()]
+  hooked-symbol LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [format{}("%cabsInt%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("INT.abs"), klabel{}("absInt"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1269,18,1269,119)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("(ite (< #1 0) (- 0 #1) #1)"), terminals{}("1101"), total{}()]
+  hooked-symbol LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [format{}("%cbitRangeInt%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}(), hook{}("INT.bitRange"), klabel{}("bitRangeInt"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1294,18,1294,103)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101")]
+  hooked-symbol Lblchoice'LParUndsRParUnds'MAP'Unds'KItem'Unds'Map{}(SortMap{}) : SortKItem{} [format{}("%cchoice%r %c(%r %1 %c)%r"), function{}(), hook{}("MAP.choice"), klabel{}("Map:choice"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(393,20,393,101)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol Lblchoice'LParUndsRParUnds'SET'Unds'KItem'Unds'Set{}(SortSet{}) : SortKItem{} [format{}("%cchoice%r %c(%r %1 %c)%r"), function{}(), hook{}("SET.choice"), klabel{}("Set:choice"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(804,20,804,95)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol LblfillList'LParUndsCommUndsCommUndsCommUndsRParUnds'LIST'Unds'List'Unds'List'Unds'Int'Unds'Int'Unds'KItem{}(SortList{}, SortInt{}, SortInt{}, SortKItem{}) : SortList{} [format{}("%cfillList%r %c(%r %1 %c,%r %2 %c,%r %3 %c,%r %4 %c)%r"), function{}(), hook{}("LIST.fill"), klabel{}("fillList"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(993,19,993,100)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101010101")]
+  symbol LblfreshInt'LParUndsRParUnds'INT'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [format{}("%cfreshInt%r %c(%r %1 %c)%r"), freshGenerator{}(), function{}(), functional{}(), klabel{}("freshInt"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1434,18,1434,77)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), private{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblgetGeneratedCounterCell{}(SortGeneratedTopCell{}) : SortGeneratedCounterCell{} [format{}("%cgetGeneratedCounterCell%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), right{}(), terminals{}("1101")]
+  symbol LblinitGeneratedCounterCell{}() : SortGeneratedCounterCell{} [format{}("%cinitGeneratedCounterCell%r"), function{}(), initializer{}(), left{}(), noThread{}(), priorities{}(), right{}(), terminals{}("1")]
+  symbol LblinitGeneratedTopCell{}(SortMap{}) : SortGeneratedTopCell{} [format{}("%cinitGeneratedTopCell%r %c(%r %1 %c)%r"), function{}(), initializer{}(), left{}(), noThread{}(), priorities{}(), right{}(), terminals{}("1101")]
+  symbol LblinitKCell{}(SortMap{}) : SortKCell{} [format{}("%cinitKCell%r %c(%r %1 %c)%r"), function{}(), initializer{}(), left{}(), noThread{}(), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol LblintersectSet'LParUndsCommUndsRParUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortSet{} [comm{}(), format{}("%cintersectSet%r %c(%r %1 %c,%r %2 %c)%r"), function{}(), functional{}(), hook{}("SET.intersection"), klabel{}("intersectSet"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(759,18,759,90)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), total{}()]
+  symbol LblisBool{}(SortK{}) : SortBool{} [format{}("%cisBool%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("Bool"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisGeneratedCounterCell{}(SortK{}) : SortBool{} [format{}("%cisGeneratedCounterCell%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("GeneratedCounterCell"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisGeneratedCounterCellOpt{}(SortK{}) : SortBool{} [format{}("%cisGeneratedCounterCellOpt%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("GeneratedCounterCellOpt"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisGeneratedTopCell{}(SortK{}) : SortBool{} [format{}("%cisGeneratedTopCell%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("GeneratedTopCell"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisGeneratedTopCellFragment{}(SortK{}) : SortBool{} [format{}("%cisGeneratedTopCellFragment%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("GeneratedTopCellFragment"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisInt{}(SortK{}) : SortBool{} [format{}("%cisInt%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("Int"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisK{}(SortK{}) : SortBool{} [format{}("%cisK%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("K"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisKCell{}(SortK{}) : SortBool{} [format{}("%cisKCell%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("KCell"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisKCellOpt{}(SortK{}) : SortBool{} [format{}("%cisKCellOpt%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("KCellOpt"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisKConfigVar{}(SortK{}) : SortBool{} [format{}("%cisKConfigVar%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("KConfigVar"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisKItem{}(SortK{}) : SortBool{} [format{}("%cisKItem%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("KItem"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisList{}(SortK{}) : SortBool{} [format{}("%cisList%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("List"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisMap{}(SortK{}) : SortBool{} [format{}("%cisMap%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("Map"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisSet{}(SortK{}) : SortBool{} [format{}("%cisSet%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("Set"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  hooked-symbol Lblkeys'LParUndsRParUnds'MAP'Unds'Set'Unds'Map{}(SortMap{}) : SortSet{} [format{}("%ckeys%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("MAP.keys"), klabel{}("keys"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(341,18,341,82)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  hooked-symbol Lblkeys'Unds'list'LParUndsRParUnds'MAP'Unds'List'Unds'Map{}(SortMap{}) : SortList{} [format{}("%ckeys_list%r %c(%r %1 %c)%r"), function{}(), hook{}("MAP.keys_list"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(349,19,349,80)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol Lbllog2Int'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [format{}("%clog2Int%r %c(%r %1 %c)%r"), function{}(), hook{}("INT.log2"), klabel{}("log2Int"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1280,18,1280,75)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol LblmakeList'LParUndsCommUndsRParUnds'LIST'Unds'List'Unds'Int'Unds'KItem{}(SortInt{}, SortKItem{}) : SortList{} [format{}("%cmakeList%r %c(... %r length: %1 %c,%r value: %2 %c)%r"), function{}(), hook{}("LIST.make"), klabel{}("makeList"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(974,19,974,82)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101")]
+  hooked-symbol LblmaxInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%cmaxInt%r %c(%r %1 %c,%r %2 %c)%r"), function{}(), functional{}(), hook{}("INT.max"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1261,18,1261,114)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("(ite (< #1 #2) #2 #1)"), terminals{}("110101"), total{}()]
+  hooked-symbol LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%cminInt%r %c(%r %1 %c,%r %2 %c)%r"), function{}(), functional{}(), hook{}("INT.min"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1260,18,1260,114)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("(ite (< #1 #2) #1 #2)"), terminals{}("110101"), total{}()]
+  symbol LblnoGeneratedCounterCell{}() : SortGeneratedCounterCellOpt{} [cellOptAbsent{}("GeneratedCounterCell"), constructor{}(), format{}("%cnoGeneratedCounterCell%r"), functional{}(), injective{}(), left{}(), priorities{}(), right{}(), terminals{}("1")]
+  symbol LblnoKCell{}() : SortKCellOpt{} [cellOptAbsent{}("KCell"), constructor{}(), format{}("%cnoKCell%r"), functional{}(), injective{}(), left{}(), priorities{}(), right{}(), terminals{}("1")]
+  hooked-symbol LblnotBool'Unds'{}(SortBool{}) : SortBool{} [boolOperation{}(), format{}("%cnotBool%r %1"), function{}(), functional{}(), hook{}("BOOL.not"), klabel{}("notBool_"), latex{}("\\neg_{\\scriptstyle\\it Bool}{#1}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1100,19,1100,179)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(Lbl'Unds'orElseBool'Unds'{}(),Lbl'Unds'orBool'Unds'{}(),Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'Unds'andThenBool'Unds'{}(),Lbl'Unds'impliesBool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}(),Lbl'Unds'andBool'Unds'{}(),Lbl'Unds'xorBool'Unds'{}()), right{}(), smt-hook{}("not"), symbol'Kywd'{}(), terminals{}("10"), total{}()]
+  symbol Lblproject'Coln'Bool{}(SortK{}) : SortBool{} [format{}("%cproject:Bool%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'GeneratedCounterCell{}(SortK{}) : SortGeneratedCounterCell{} [format{}("%cproject:GeneratedCounterCell%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'GeneratedCounterCellOpt{}(SortK{}) : SortGeneratedCounterCellOpt{} [format{}("%cproject:GeneratedCounterCellOpt%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'GeneratedTopCell{}(SortK{}) : SortGeneratedTopCell{} [format{}("%cproject:GeneratedTopCell%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'GeneratedTopCellFragment{}(SortK{}) : SortGeneratedTopCellFragment{} [format{}("%cproject:GeneratedTopCellFragment%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'Int{}(SortK{}) : SortInt{} [format{}("%cproject:Int%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'K{}(SortK{}) : SortK{} [format{}("%cproject:K%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'KCell{}(SortK{}) : SortKCell{} [format{}("%cproject:KCell%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'KCellOpt{}(SortK{}) : SortKCellOpt{} [format{}("%cproject:KCellOpt%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'KItem{}(SortK{}) : SortKItem{} [format{}("%cproject:KItem%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'List{}(SortK{}) : SortList{} [format{}("%cproject:List%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'Map{}(SortK{}) : SortMap{} [format{}("%cproject:Map%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'Set{}(SortK{}) : SortSet{} [format{}("%cproject:Set%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  hooked-symbol LblrandInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [format{}("%crandInt%r %c(%r %1 %c)%r"), function{}(), hook{}("INT.rand"), impure{}(), klabel{}("randInt"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1328,18,1328,65)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol LblremoveAll'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Set{}(SortMap{}, SortSet{}) : SortMap{} [format{}("%cremoveAll%r %c(%r %1 %c,%r %2 %c)%r"), function{}(), functional{}(), hook{}("MAP.removeAll"), klabel{}("removeAll"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(333,18,333,87)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), total{}()]
+  hooked-symbol LblsignExtendBitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [format{}("%csignExtendBitRangeInt%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}(), hook{}("INT.signExtendBitRange"), klabel{}("signExtendBitRangeInt"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1295,18,1295,113)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101")]
+  hooked-symbol Lblsize'LParUndsRParUnds'LIST'Unds'Int'Unds'List{}(SortList{}) : SortInt{} [format{}("%csize%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("LIST.size"), klabel{}("sizeList"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1020,18,1020,117)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smtlib{}("smt_seq_len"), terminals{}("1101"), total{}()]
+  hooked-symbol Lblsize'LParUndsRParUnds'MAP'Unds'Int'Unds'Map{}(SortMap{}) : SortInt{} [format{}("%csize%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("MAP.size"), klabel{}("sizeMap"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(373,18,373,99)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  hooked-symbol Lblsize'LParUndsRParUnds'SET'Unds'Int'Unds'Set{}(SortSet{}) : SortInt{} [format{}("%csize%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("SET.size"), klabel{}("size"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(794,18,794,76)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  hooked-symbol LblsrandInt'LParUndsRParUnds'INT-COMMON'Unds'K'Unds'Int{}(SortInt{}) : SortK{} [format{}("%csrandInt%r %c(%r %1 %c)%r"), function{}(), hook{}("INT.srand"), impure{}(), klabel{}("srandInt"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1329,16,1329,65)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol LblupdateList'LParUndsCommUndsCommUndsRParUnds'LIST'Unds'List'Unds'List'Unds'Int'Unds'List{}(SortList{}, SortInt{}, SortList{}) : SortList{} [format{}("%cupdateList%r %c(... %r dest: %1 %c,%r index: %2 %c,%r src: %3 %c)%r"), function{}(), hook{}("LIST.updateAll"), klabel{}("updateList"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(984,19,984,97)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101")]
+  hooked-symbol LblupdateMap'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortMap{} [format{}("%cupdateMap%r %c(%r %1 %c,%r %2 %c)%r"), function{}(), functional{}(), hook{}("MAP.updateAll"), klabel{}("updateMap"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(324,18,324,87)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), total{}()]
+  hooked-symbol Lblvalues'LParUndsRParUnds'MAP'Unds'List'Unds'Map{}(SortMap{}) : SortList{} [format{}("%cvalues%r %c(%r %1 %c)%r"), function{}(), hook{}("MAP.values"), klabel{}("values"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(365,19,365,77)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol Lbl'Tild'Int'Unds'{}(SortInt{}) : SortInt{} [format{}("%c~Int%r %1"), function{}(), functional{}(), hook{}("INT.not"), klabel{}("~Int_"), latex{}("\\mathop{\\sim_{\\scriptstyle\\it Int}}{#1}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1228,18,1228,168)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'UndsXor-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'UndsXor-Perc'Int'UndsUnds'{}(),Lbl'Unds'-Int'Unds'{}()), right{}(), smtlib{}("notInt"), symbol'Kywd'{}(), terminals{}("10"), total{}()]
+
+// generated axioms
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortKCellOpt{}, SortKItem{}} (From:SortKCellOpt{}))) [subsort{SortKCellOpt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedCounterCellOpt{}, SortKItem{}} (From:SortGeneratedCounterCellOpt{}))) [subsort{SortGeneratedCounterCellOpt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortGeneratedCounterCellOpt{}, \equals{SortGeneratedCounterCellOpt{}, R} (Val:SortGeneratedCounterCellOpt{}, inj{SortGeneratedCounterCell{}, SortGeneratedCounterCellOpt{}} (From:SortGeneratedCounterCell{}))) [subsort{SortGeneratedCounterCell{}, SortGeneratedCounterCellOpt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortKCell{}, SortKItem{}} (From:SortKCell{}))) [subsort{SortKCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKCellOpt{}, \equals{SortKCellOpt{}, R} (Val:SortKCellOpt{}, inj{SortKCell{}, SortKCellOpt{}} (From:SortKCell{}))) [subsort{SortKCell{}, SortKCellOpt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortSet{}, SortKItem{}} (From:SortSet{}))) [subsort{SortSet{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedCounterCell{}, SortKItem{}} (From:SortGeneratedCounterCell{}))) [subsort{SortGeneratedCounterCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedTopCell{}, SortKItem{}} (From:SortGeneratedTopCell{}))) [subsort{SortGeneratedTopCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortList{}, SortKItem{}} (From:SortList{}))) [subsort{SortList{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortKConfigVar{}, SortKItem{}} (From:SortKConfigVar{}))) [subsort{SortKConfigVar{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortBool{}, SortKItem{}} (From:SortBool{}))) [subsort{SortBool{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortInt{}, SortKItem{}} (From:SortInt{}))) [subsort{SortInt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedTopCellFragment{}, SortKItem{}} (From:SortGeneratedTopCellFragment{}))) [subsort{SortGeneratedTopCellFragment{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortMap{}, SortKItem{}} (From:SortMap{}))) [subsort{SortMap{}, SortKItem{}}()] // subsort
+  axiom{R, SortSort} \exists{R} (Val:SortSort, \equals{SortSort, R} (Val:SortSort, Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL-SYNTAX'Unds'Sort'Unds'Bool'Unds'Sort'Unds'Sort{SortSort}(K0:SortBool{}, K1:SortSort, K2:SortSort))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, Lbl'Stop'List{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'Stop'Map{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lbl'Stop'Set{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortGeneratedCounterCell{}, \equals{SortGeneratedCounterCell{}, R} (Val:SortGeneratedCounterCell{}, Lbl'-LT-'generatedCounter'-GT-'{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{}\implies{SortGeneratedCounterCell{}} (\and{SortGeneratedCounterCell{}} (Lbl'-LT-'generatedCounter'-GT-'{}(X0:SortInt{}), Lbl'-LT-'generatedCounter'-GT-'{}(Y0:SortInt{})), Lbl'-LT-'generatedCounter'-GT-'{}(\and{SortInt{}} (X0:SortInt{}, Y0:SortInt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortGeneratedTopCell{}, \equals{SortGeneratedTopCell{}, R} (Val:SortGeneratedTopCell{}, Lbl'-LT-'generatedTop'-GT-'{}(K0:SortKCell{}, K1:SortGeneratedCounterCell{}))) [functional{}()] // functional
+  axiom{}\implies{SortGeneratedTopCell{}} (\and{SortGeneratedTopCell{}} (Lbl'-LT-'generatedTop'-GT-'{}(X0:SortKCell{}, X1:SortGeneratedCounterCell{}), Lbl'-LT-'generatedTop'-GT-'{}(Y0:SortKCell{}, Y1:SortGeneratedCounterCell{})), Lbl'-LT-'generatedTop'-GT-'{}(\and{SortKCell{}} (X0:SortKCell{}, Y0:SortKCell{}), \and{SortGeneratedCounterCell{}} (X1:SortGeneratedCounterCell{}, Y1:SortGeneratedCounterCell{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortGeneratedTopCellFragment{}, \equals{SortGeneratedTopCellFragment{}, R} (Val:SortGeneratedTopCellFragment{}, Lbl'-LT-'generatedTop'-GT-'-fragment{}(K0:SortKCellOpt{}, K1:SortGeneratedCounterCellOpt{}))) [functional{}()] // functional
+  axiom{}\implies{SortGeneratedTopCellFragment{}} (\and{SortGeneratedTopCellFragment{}} (Lbl'-LT-'generatedTop'-GT-'-fragment{}(X0:SortKCellOpt{}, X1:SortGeneratedCounterCellOpt{}), Lbl'-LT-'generatedTop'-GT-'-fragment{}(Y0:SortKCellOpt{}, Y1:SortGeneratedCounterCellOpt{})), Lbl'-LT-'generatedTop'-GT-'-fragment{}(\and{SortKCellOpt{}} (X0:SortKCellOpt{}, Y0:SortKCellOpt{}), \and{SortGeneratedCounterCellOpt{}} (X1:SortGeneratedCounterCellOpt{}, Y1:SortGeneratedCounterCellOpt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortKCell{}, \equals{SortKCell{}, R} (Val:SortKCell{}, Lbl'-LT-'k'-GT-'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKCell{}} (\and{SortKCell{}} (Lbl'-LT-'k'-GT-'{}(X0:SortK{}), Lbl'-LT-'k'-GT-'{}(Y0:SortK{})), Lbl'-LT-'k'-GT-'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, LblListItem{}(K0:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, LblMap'Coln'update{}(K0:SortMap{}, K1:SortKItem{}, K2:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblSet'Coln'difference{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblSet'Coln'in{}(K0:SortKItem{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblSetItem{}(K0:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsAnd-'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsStar'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsPlus'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Unds'-Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'Unds'-Map'UndsUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Map'UndsUnds'MAP'Unds'Bool'Unds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Set'UndsUnds'SET'Unds'Bool'Unds'Set'Unds'Set{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'K'Unds'{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'Bool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'K'Unds'{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-Eqls'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \equals{SortList{}, R} (Lbl'Unds'List'Unds'{}(Lbl'Unds'List'Unds'{}(K1:SortList{},K2:SortList{}),K3:SortList{}),Lbl'Unds'List'Unds'{}(K1:SortList{},Lbl'Unds'List'Unds'{}(K2:SortList{},K3:SortList{}))) [assoc{}()] // associativity
+  axiom{R}\equals{SortList{}, R} (Lbl'Unds'List'Unds'{}(K:SortList{},Lbl'Stop'List{}()),K:SortList{}) [unit{}()] // right unit
+  axiom{R}\equals{SortList{}, R} (Lbl'Unds'List'Unds'{}(Lbl'Stop'List{}(),K:SortList{}),K:SortList{}) [unit{}()] // left unit
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, Lbl'Unds'List'Unds'{}(K0:SortList{}, K1:SortList{}))) [functional{}()] // functional
+  axiom{R} \equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(Lbl'Unds'Map'Unds'{}(K1:SortMap{},K2:SortMap{}),K3:SortMap{}),Lbl'Unds'Map'Unds'{}(K1:SortMap{},Lbl'Unds'Map'Unds'{}(K2:SortMap{},K3:SortMap{}))) [assoc{}()] // associativity
+  axiom{R}\equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(K:SortMap{},Lbl'Stop'Map{}()),K:SortMap{}) [unit{}()] // right unit
+  axiom{R}\equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(Lbl'Stop'Map{}(),K:SortMap{}),K:SortMap{}) [unit{}()] // left unit
+  axiom{R} \equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(Lbl'Unds'Set'Unds'{}(K1:SortSet{},K2:SortSet{}),K3:SortSet{}),Lbl'Unds'Set'Unds'{}(K1:SortSet{},Lbl'Unds'Set'Unds'{}(K2:SortSet{},K3:SortSet{}))) [assoc{}()] // associativity
+  axiom{R} \equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(K:SortSet{},K:SortSet{}),K:SortSet{}) [idem{}()] // idempotency
+  axiom{R}\equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(K:SortSet{},Lbl'Stop'Set{}()),K:SortSet{}) [unit{}()] // right unit
+  axiom{R}\equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(Lbl'Stop'Set{}(),K:SortSet{}),K:SortSet{}) [unit{}()] // left unit
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'UndsLSqBUnds-LT-'-undef'RSqB'{}(K0:SortMap{}, K1:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'UndsLSqBUndsRSqB'orDefault'UndsUnds'MAP'Unds'KItem'Unds'Map'Unds'KItem'Unds'KItem{}(K0:SortMap{}, K1:SortKItem{}, K2:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'andBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'andThenBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'impliesBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'in'UndsUnds'LIST'Unds'Bool'Unds'KItem'Unds'List{}(K0:SortKItem{}, K1:SortList{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'Unds'Bool'Unds'KItem'Unds'Map{}(K0:SortKItem{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'orBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'orElseBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'xorBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Unds'xorInt'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'UndsPipe'-'-GT-Unds'{}(K0:SortKItem{}, K1:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsPipe'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblfreshInt'LParUndsRParUnds'INT'Unds'Int'Unds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblintersectSet'LParUndsCommUndsRParUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisBool{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisGeneratedCounterCell{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisGeneratedCounterCellOpt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisGeneratedTopCell{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisGeneratedTopCellFragment{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisInt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisK{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKCell{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKCellOpt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKConfigVar{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKItem{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisList{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisMap{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisSet{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lblkeys'LParUndsRParUnds'MAP'Unds'Set'Unds'Map{}(K0:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblmaxInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortGeneratedCounterCellOpt{}, \equals{SortGeneratedCounterCellOpt{}, R} (Val:SortGeneratedCounterCellOpt{}, LblnoGeneratedCounterCell{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKCellOpt{}, \equals{SortKCellOpt{}, R} (Val:SortKCellOpt{}, LblnoKCell{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblnotBool'Unds'{}(K0:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, LblremoveAll'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Set{}(K0:SortMap{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lblsize'LParUndsRParUnds'LIST'Unds'Int'Unds'List{}(K0:SortList{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lblsize'LParUndsRParUnds'MAP'Unds'Int'Unds'Map{}(K0:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lblsize'LParUndsRParUnds'SET'Unds'Int'Unds'Set{}(K0:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, LblupdateMap'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Tild'Int'Unds'{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{} \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortList{}, inj{SortList{}, SortKItem{}} (Val:SortList{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKConfigVar{}, inj{SortKConfigVar{}, SortKItem{}} (Val:SortKConfigVar{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortGeneratedCounterCellOpt{}, inj{SortGeneratedCounterCellOpt{}, SortKItem{}} (Val:SortGeneratedCounterCellOpt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortGeneratedCounterCell{}, inj{SortGeneratedCounterCell{}, SortKItem{}} (Val:SortGeneratedCounterCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortBool{}, inj{SortBool{}, SortKItem{}} (Val:SortBool{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKCell{}, inj{SortKCell{}, SortKItem{}} (Val:SortKCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortMap{}, inj{SortMap{}, SortKItem{}} (Val:SortMap{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKCellOpt{}, inj{SortKCellOpt{}, SortKItem{}} (Val:SortKCellOpt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortInt{}, inj{SortInt{}, SortKItem{}} (Val:SortInt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortGeneratedTopCell{}, inj{SortGeneratedTopCell{}, SortKItem{}} (Val:SortGeneratedTopCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortSet{}, inj{SortSet{}, SortKItem{}} (Val:SortSet{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortGeneratedTopCellFragment{}, inj{SortGeneratedTopCellFragment{}, SortKItem{}} (Val:SortGeneratedTopCellFragment{})), \bottom{SortKItem{}}())))))))))))) [constructor{}()] // no junk
+  axiom{} \or{SortKConfigVar{}} (\top{SortKConfigVar{}}(), \bottom{SortKConfigVar{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortGeneratedCounterCellOpt{}} (LblnoGeneratedCounterCell{}(), \or{SortGeneratedCounterCellOpt{}} (\exists{SortGeneratedCounterCellOpt{}} (Val:SortGeneratedCounterCell{}, inj{SortGeneratedCounterCell{}, SortGeneratedCounterCellOpt{}} (Val:SortGeneratedCounterCell{})), \bottom{SortGeneratedCounterCellOpt{}}())) [constructor{}()] // no junk
+  axiom{} \or{SortGeneratedCounterCell{}} (\exists{SortGeneratedCounterCell{}} (X0:SortInt{}, Lbl'-LT-'generatedCounter'-GT-'{}(X0:SortInt{})), \bottom{SortGeneratedCounterCell{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortBool{}} (\top{SortBool{}}(), \bottom{SortBool{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortKCell{}} (\exists{SortKCell{}} (X0:SortK{}, Lbl'-LT-'k'-GT-'{}(X0:SortK{})), \bottom{SortKCell{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortKCellOpt{}} (LblnoKCell{}(), \or{SortKCellOpt{}} (\exists{SortKCellOpt{}} (Val:SortKCell{}, inj{SortKCell{}, SortKCellOpt{}} (Val:SortKCell{})), \bottom{SortKCellOpt{}}())) [constructor{}()] // no junk
+  axiom{} \or{SortInt{}} (\top{SortInt{}}(), \bottom{SortInt{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortGeneratedTopCell{}} (\exists{SortGeneratedTopCell{}} (X0:SortKCell{}, \exists{SortGeneratedTopCell{}} (X1:SortGeneratedCounterCell{}, Lbl'-LT-'generatedTop'-GT-'{}(X0:SortKCell{}, X1:SortGeneratedCounterCell{}))), \bottom{SortGeneratedTopCell{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortGeneratedTopCellFragment{}} (\exists{SortGeneratedTopCellFragment{}} (X0:SortKCellOpt{}, \exists{SortGeneratedTopCellFragment{}} (X1:SortGeneratedCounterCellOpt{}, Lbl'-LT-'generatedTop'-GT-'-fragment{}(X0:SortKCellOpt{}, X1:SortGeneratedCounterCellOpt{}))), \bottom{SortGeneratedTopCellFragment{}}()) [constructor{}()] // no junk
+
+// rules
+// rule #Ceil{Int,#SortParam}(`_%Int_`(@I1,@I2))=>#And{#SortParam}(#And{#SortParam}(#Equals{Bool,#SortParam}(`_=/=Int_`(@I2,#token("0","Int")),#token("true","Bool")),#Ceil{Int,#SortParam}(@I1)),#Ceil{Int,#SortParam}(@I2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(277564ad2537209fd698729ceaa01973f97125176cf1078f98e2edb7cc190f34), org.kframework.attributes.Location(Location(1369,8,1369,102)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, sortParams({Q0})]
+  axiom{R,Q0} \implies{R} (
+    \top{R}(),
+    \equals{Q0,R} (
+      \ceil{SortInt{}, Q0}(Lbl'UndsPerc'Int'Unds'{}(@VarI1:SortInt{},@VarI2:SortInt{})),
+     \and{Q0} (
+       \and{Q0}(\and{Q0}(\equals{SortBool{}, Q0}(Lbl'UndsEqlsSlshEqls'Int'Unds'{}(@VarI2:SortInt{},\dv{SortInt{}}("0")),\dv{SortBool{}}("true")),\ceil{SortInt{}, Q0}(@VarI1:SortInt{})),\ceil{SortInt{}, Q0}(@VarI2:SortInt{})),
+        \top{Q0}())))
+  [UNIQUE'Unds'ID{}("277564ad2537209fd698729ceaa01973f97125176cf1078f98e2edb7cc190f34"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1369,8,1369,102)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), sortParams{}("{Q0}")]
+
+// rule #Ceil{Int,#SortParam}(`_/Int_`(@I1,@I2))=>#And{#SortParam}(#And{#SortParam}(#Equals{Bool,#SortParam}(`_=/=Int_`(@I2,#token("0","Int")),#token("true","Bool")),#Ceil{Int,#SortParam}(@I1)),#Ceil{Int,#SortParam}(@I2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(1eefe48360417c30b8e5f115a539adbc38e337fa903d6c589811e7b619f8d1cd), org.kframework.attributes.Location(Location(1368,8,1368,102)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, sortParams({Q0})]
+  axiom{R,Q0} \implies{R} (
+    \top{R}(),
+    \equals{Q0,R} (
+      \ceil{SortInt{}, Q0}(Lbl'UndsSlsh'Int'Unds'{}(@VarI1:SortInt{},@VarI2:SortInt{})),
+     \and{Q0} (
+       \and{Q0}(\and{Q0}(\equals{SortBool{}, Q0}(Lbl'UndsEqlsSlshEqls'Int'Unds'{}(@VarI2:SortInt{},\dv{SortInt{}}("0")),\dv{SortBool{}}("true")),\ceil{SortInt{}, Q0}(@VarI1:SortInt{})),\ceil{SortInt{}, Q0}(@VarI2:SortInt{})),
+        \top{Q0}())))
+  [UNIQUE'Unds'ID{}("1eefe48360417c30b8e5f115a539adbc38e337fa903d6c589811e7b619f8d1cd"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1368,8,1368,102)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), sortParams{}("{Q0}")]
+
+// rule #Ceil{Int,#SortParam}(`_<<Int_`(@I1,@I2))=>#And{#SortParam}(#And{#SortParam}(#Equals{Bool,#SortParam}(`_>=Int_`(@I2,#token("0","Int")),#token("true","Bool")),#Ceil{Int,#SortParam}(@I1)),#Ceil{Int,#SortParam}(@I2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(0b052005b3756fb7082a3e365e1de3b170b4b0d828aab504a9ec2cfd19666528), org.kframework.attributes.Location(Location(1372,8,1372,102)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, sortParams({Q0})]
+  axiom{R,Q0} \implies{R} (
+    \top{R}(),
+    \equals{Q0,R} (
+      \ceil{SortInt{}, Q0}(Lbl'Unds-LT--LT-'Int'Unds'{}(@VarI1:SortInt{},@VarI2:SortInt{})),
+     \and{Q0} (
+       \and{Q0}(\and{Q0}(\equals{SortBool{}, Q0}(Lbl'Unds-GT-Eqls'Int'Unds'{}(@VarI2:SortInt{},\dv{SortInt{}}("0")),\dv{SortBool{}}("true")),\ceil{SortInt{}, Q0}(@VarI1:SortInt{})),\ceil{SortInt{}, Q0}(@VarI2:SortInt{})),
+        \top{Q0}())))
+  [UNIQUE'Unds'ID{}("0b052005b3756fb7082a3e365e1de3b170b4b0d828aab504a9ec2cfd19666528"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1372,8,1372,102)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), sortParams{}("{Q0}")]
+
+// rule #Ceil{Int,#SortParam}(`_>>Int_`(@I1,@I2))=>#And{#SortParam}(#And{#SortParam}(#Equals{Bool,#SortParam}(`_>=Int_`(@I2,#token("0","Int")),#token("true","Bool")),#Ceil{Int,#SortParam}(@I1)),#Ceil{Int,#SortParam}(@I2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(8504798d0c71a9c32788426e50147e59ac302592e16aa6bae4511370fd436af8), org.kframework.attributes.Location(Location(1371,8,1371,102)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, sortParams({Q0})]
+  axiom{R,Q0} \implies{R} (
+    \top{R}(),
+    \equals{Q0,R} (
+      \ceil{SortInt{}, Q0}(Lbl'Unds-GT--GT-'Int'Unds'{}(@VarI1:SortInt{},@VarI2:SortInt{})),
+     \and{Q0} (
+       \and{Q0}(\and{Q0}(\equals{SortBool{}, Q0}(Lbl'Unds-GT-Eqls'Int'Unds'{}(@VarI2:SortInt{},\dv{SortInt{}}("0")),\dv{SortBool{}}("true")),\ceil{SortInt{}, Q0}(@VarI1:SortInt{})),\ceil{SortInt{}, Q0}(@VarI2:SortInt{})),
+        \top{Q0}())))
+  [UNIQUE'Unds'ID{}("8504798d0c71a9c32788426e50147e59ac302592e16aa6bae4511370fd436af8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1371,8,1371,102)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), sortParams{}("{Q0}")]
+
+// rule #Ceil{Int,#SortParam}(`_modInt_`(@I1,@I2))=>#And{#SortParam}(#And{#SortParam}(#Equals{Bool,#SortParam}(`_=/=Int_`(@I2,#token("0","Int")),#token("true","Bool")),#Ceil{Int,#SortParam}(@I1)),#Ceil{Int,#SortParam}(@I2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f864cd1e17e48500bc78b5fa83b901031cdbfd8f0575388667ce1475a2a7f532), org.kframework.attributes.Location(Location(1370,8,1370,102)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, sortParams({Q0})]
+  axiom{R,Q0} \implies{R} (
+    \top{R}(),
+    \equals{Q0,R} (
+      \ceil{SortInt{}, Q0}(Lbl'Unds'modInt'Unds'{}(@VarI1:SortInt{},@VarI2:SortInt{})),
+     \and{Q0} (
+       \and{Q0}(\and{Q0}(\equals{SortBool{}, Q0}(Lbl'UndsEqlsSlshEqls'Int'Unds'{}(@VarI2:SortInt{},\dv{SortInt{}}("0")),\dv{SortBool{}}("true")),\ceil{SortInt{}, Q0}(@VarI1:SortInt{})),\ceil{SortInt{}, Q0}(@VarI2:SortInt{})),
+        \top{Q0}())))
+  [UNIQUE'Unds'ID{}("f864cd1e17e48500bc78b5fa83b901031cdbfd8f0575388667ce1475a2a7f532"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1370,8,1370,102)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), sortParams{}("{Q0}")]
+
+// rule #Equals{Bool,#SortParam}(`_=/=Int_`(K1,K2),#token("false","Bool"))=>#Equals{Int,#SortParam}(K1,K2) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(1b2f0c28a758d91c183983c16b5c28434ae93f4bc5f72c42ff26e578bbe9e778), org.kframework.attributes.Location(Location(1404,8,1404,55)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, sortParams({Q0})]
+  axiom{R,Q0} \implies{R} (
+    \top{R}(),
+    \equals{Q0,R} (
+      \equals{SortBool{}, Q0}(Lbl'UndsEqlsSlshEqls'Int'Unds'{}(VarK1:SortInt{},VarK2:SortInt{}),\dv{SortBool{}}("false")),
+     \and{Q0} (
+       \equals{SortInt{}, Q0}(VarK1:SortInt{},VarK2:SortInt{}),
+        \top{Q0}())))
+  [UNIQUE'Unds'ID{}("1b2f0c28a758d91c183983c16b5c28434ae93f4bc5f72c42ff26e578bbe9e778"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1404,8,1404,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), sortParams{}("{Q0}")]
+
+// rule #Equals{Bool,#SortParam}(`_=/=Int_`(K1,K2),#token("true","Bool"))=>#Not{#SortParam}(#Equals{Int,#SortParam}(K1,K2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(415c2e6721f051830c68e88f4f1e28d01ef3a444ee893de275777f8da52ee675), org.kframework.attributes.Location(Location(1402,8,1402,60)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, sortParams({Q0})]
+  axiom{R,Q0} \implies{R} (
+    \top{R}(),
+    \equals{Q0,R} (
+      \equals{SortBool{}, Q0}(Lbl'UndsEqlsSlshEqls'Int'Unds'{}(VarK1:SortInt{},VarK2:SortInt{}),\dv{SortBool{}}("true")),
+     \and{Q0} (
+       \not{Q0}(\equals{SortInt{}, Q0}(VarK1:SortInt{},VarK2:SortInt{})),
+        \top{Q0}())))
+  [UNIQUE'Unds'ID{}("415c2e6721f051830c68e88f4f1e28d01ef3a444ee893de275777f8da52ee675"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1402,8,1402,60)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), sortParams{}("{Q0}")]
+
+// rule #Equals{Bool,#SortParam}(`_=/=K_`(K1,K2),#token("false","Bool"))=>#Equals{K,#SortParam}(K1,K2) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7e3c2755de9f56727e93033164148b26514ac3266a4968788a9da9e314f085a2), org.kframework.attributes.Location(Location(2279,8,2279,53)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, sortParams({Q0})]
+  axiom{R,Q0} \implies{R} (
+    \top{R}(),
+    \equals{Q0,R} (
+      \equals{SortBool{}, Q0}(Lbl'UndsEqlsSlshEqls'K'Unds'{}(VarK1:SortK{},VarK2:SortK{}),\dv{SortBool{}}("false")),
+     \and{Q0} (
+       \equals{SortK{}, Q0}(VarK1:SortK{},VarK2:SortK{}),
+        \top{Q0}())))
+  [UNIQUE'Unds'ID{}("7e3c2755de9f56727e93033164148b26514ac3266a4968788a9da9e314f085a2"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2279,8,2279,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), sortParams{}("{Q0}")]
+
+// rule #Equals{Bool,#SortParam}(`_=/=K_`(K1,K2),#token("true","Bool"))=>#Not{#SortParam}(#Equals{K,#SortParam}(K1,K2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9130be811669fe4a43adca72c6c6019dd71bbc3230adf9d3aec48a8a4f0902a5), org.kframework.attributes.Location(Location(2277,8,2277,58)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, sortParams({Q0})]
+  axiom{R,Q0} \implies{R} (
+    \top{R}(),
+    \equals{Q0,R} (
+      \equals{SortBool{}, Q0}(Lbl'UndsEqlsSlshEqls'K'Unds'{}(VarK1:SortK{},VarK2:SortK{}),\dv{SortBool{}}("true")),
+     \and{Q0} (
+       \not{Q0}(\equals{SortK{}, Q0}(VarK1:SortK{},VarK2:SortK{})),
+        \top{Q0}())))
+  [UNIQUE'Unds'ID{}("9130be811669fe4a43adca72c6c6019dd71bbc3230adf9d3aec48a8a4f0902a5"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2277,8,2277,58)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), sortParams{}("{Q0}")]
+
+// rule #Equals{Bool,#SortParam}(`_==Int_`(K1,K2),#token("false","Bool"))=>#Not{#SortParam}(#Equals{Int,#SortParam}(K1,K2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(3fbd49f516b65c441727e322cf239d04b588af705f2f55c0809e19c84453adc8), org.kframework.attributes.Location(Location(1400,8,1400,60)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, sortParams({Q0})]
+  axiom{R,Q0} \implies{R} (
+    \top{R}(),
+    \equals{Q0,R} (
+      \equals{SortBool{}, Q0}(Lbl'UndsEqlsEqls'Int'Unds'{}(VarK1:SortInt{},VarK2:SortInt{}),\dv{SortBool{}}("false")),
+     \and{Q0} (
+       \not{Q0}(\equals{SortInt{}, Q0}(VarK1:SortInt{},VarK2:SortInt{})),
+        \top{Q0}())))
+  [UNIQUE'Unds'ID{}("3fbd49f516b65c441727e322cf239d04b588af705f2f55c0809e19c84453adc8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1400,8,1400,60)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), sortParams{}("{Q0}")]
+
+// rule #Equals{Bool,#SortParam}(`_==Int_`(K1,K2),#token("true","Bool"))=>#Equals{Int,#SortParam}(K1,K2) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2ef27a628b08283a24d379050acde3bad9d410fe40366d9b4ffecb885e0f69a1), org.kframework.attributes.Location(Location(1398,8,1398,53)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, sortParams({Q0})]
+  axiom{R,Q0} \implies{R} (
+    \top{R}(),
+    \equals{Q0,R} (
+      \equals{SortBool{}, Q0}(Lbl'UndsEqlsEqls'Int'Unds'{}(VarK1:SortInt{},VarK2:SortInt{}),\dv{SortBool{}}("true")),
+     \and{Q0} (
+       \equals{SortInt{}, Q0}(VarK1:SortInt{},VarK2:SortInt{}),
+        \top{Q0}())))
+  [UNIQUE'Unds'ID{}("2ef27a628b08283a24d379050acde3bad9d410fe40366d9b4ffecb885e0f69a1"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1398,8,1398,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), sortParams{}("{Q0}")]
+
+// rule #Equals{Bool,#SortParam}(`_==K_`(K1,K2),#token("false","Bool"))=>#Not{#SortParam}(#Equals{K,#SortParam}(K1,K2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(6bd0e33cfd9a06f8dafd28aada596b748f8ad71d7a6b0d5d06b4ec8bd3c17ae6), org.kframework.attributes.Location(Location(2275,8,2275,58)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, sortParams({Q0})]
+  axiom{R,Q0} \implies{R} (
+    \top{R}(),
+    \equals{Q0,R} (
+      \equals{SortBool{}, Q0}(Lbl'UndsEqlsEqls'K'Unds'{}(VarK1:SortK{},VarK2:SortK{}),\dv{SortBool{}}("false")),
+     \and{Q0} (
+       \not{Q0}(\equals{SortK{}, Q0}(VarK1:SortK{},VarK2:SortK{})),
+        \top{Q0}())))
+  [UNIQUE'Unds'ID{}("6bd0e33cfd9a06f8dafd28aada596b748f8ad71d7a6b0d5d06b4ec8bd3c17ae6"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2275,8,2275,58)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), sortParams{}("{Q0}")]
+
+// rule #Equals{Bool,#SortParam}(`_==K_`(K1,K2),#token("true","Bool"))=>#Equals{K,#SortParam}(K1,K2) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(34091c658d74ff4f694390d20661da89dbe79df122c20fb96f99d0b4a0362f92), org.kframework.attributes.Location(Location(2273,8,2273,51)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, sortParams({Q0})]
+  axiom{R,Q0} \implies{R} (
+    \top{R}(),
+    \equals{Q0,R} (
+      \equals{SortBool{}, Q0}(Lbl'UndsEqlsEqls'K'Unds'{}(VarK1:SortK{},VarK2:SortK{}),\dv{SortBool{}}("true")),
+     \and{Q0} (
+       \equals{SortK{}, Q0}(VarK1:SortK{},VarK2:SortK{}),
+        \top{Q0}())))
+  [UNIQUE'Unds'ID{}("34091c658d74ff4f694390d20661da89dbe79df122c20fb96f99d0b4a0362f92"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2273,8,2273,51)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), sortParams{}("{Q0}")]
+
+// rule #Equals{Bool,#SortParam}(`_andBool_`(@B1,@B2),#token("true","Bool"))=>#And{#SortParam}(#Equals{Bool,#SortParam}(@B1,#token("true","Bool")),#Equals{Bool,#SortParam}(@B2,#token("true","Bool"))) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(07baa96fd82cc826cf1685cb8119bf1c214ed8b884464ffe20e53b993c12e918), org.kframework.attributes.Location(Location(1162,8,1162,84)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, sortParams({Q0})]
+  axiom{R,Q0} \implies{R} (
+    \top{R}(),
+    \equals{Q0,R} (
+      \equals{SortBool{}, Q0}(Lbl'Unds'andBool'Unds'{}(@VarB1:SortBool{},@VarB2:SortBool{}),\dv{SortBool{}}("true")),
+     \and{Q0} (
+       \and{Q0}(\equals{SortBool{}, Q0}(@VarB1:SortBool{},\dv{SortBool{}}("true")),\equals{SortBool{}, Q0}(@VarB2:SortBool{},\dv{SortBool{}}("true"))),
+        \top{Q0}())))
+  [UNIQUE'Unds'ID{}("07baa96fd82cc826cf1685cb8119bf1c214ed8b884464ffe20e53b993c12e918"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1162,8,1162,84)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), sortParams{}("{Q0}")]
+
+// rule #Equals{Bool,#SortParam}(`_orBool_`(@B1,@B2),#token("false","Bool"))=>#And{#SortParam}(#Equals{Bool,#SortParam}(@B1,#token("false","Bool")),#Equals{Bool,#SortParam}(@B2,#token("false","Bool"))) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2b11ac075f3dd3ffe0ddbec1741072a8869b134229fe049807754e8ad343744e), org.kframework.attributes.Location(Location(1164,8,1164,86)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, sortParams({Q0})]
+  axiom{R,Q0} \implies{R} (
+    \top{R}(),
+    \equals{Q0,R} (
+      \equals{SortBool{}, Q0}(Lbl'Unds'orBool'Unds'{}(@VarB1:SortBool{},@VarB2:SortBool{}),\dv{SortBool{}}("false")),
+     \and{Q0} (
+       \and{Q0}(\equals{SortBool{}, Q0}(@VarB1:SortBool{},\dv{SortBool{}}("false")),\equals{SortBool{}, Q0}(@VarB2:SortBool{},\dv{SortBool{}}("false"))),
+        \top{Q0}())))
+  [UNIQUE'Unds'ID{}("2b11ac075f3dd3ffe0ddbec1741072a8869b134229fe049807754e8ad343744e"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1164,8,1164,86)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), sortParams{}("{Q0}")]
+
+// rule #Equals{Bool,#SortParam}(`notBool_`(@B),#token("false","Bool"))=>#Equals{Bool,#SortParam}(@B,#token("true","Bool")) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(34328f07490eae9a3c60959e6bc930879eadfd5c2141758b8ee518c2fb0204ad), org.kframework.attributes.Location(Location(1159,8,1159,55)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, sortParams({Q0})]
+  axiom{R,Q0} \implies{R} (
+    \top{R}(),
+    \equals{Q0,R} (
+      \equals{SortBool{}, Q0}(LblnotBool'Unds'{}(@VarB:SortBool{}),\dv{SortBool{}}("false")),
+     \and{Q0} (
+       \equals{SortBool{}, Q0}(@VarB:SortBool{},\dv{SortBool{}}("true")),
+        \top{Q0}())))
+  [UNIQUE'Unds'ID{}("34328f07490eae9a3c60959e6bc930879eadfd5c2141758b8ee518c2fb0204ad"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1159,8,1159,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), sortParams{}("{Q0}")]
+
+// rule #Equals{Bool,#SortParam}(`notBool_`(@B),#token("true","Bool"))=>#Equals{Bool,#SortParam}(@B,#token("false","Bool")) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(ff38a911e0bfd4c9765658dd908e0ef2ceee912f22703ddb571af28ef362bc9e), org.kframework.attributes.Location(Location(1157,8,1157,55)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, sortParams({Q0})]
+  axiom{R,Q0} \implies{R} (
+    \top{R}(),
+    \equals{Q0,R} (
+      \equals{SortBool{}, Q0}(LblnotBool'Unds'{}(@VarB:SortBool{}),\dv{SortBool{}}("true")),
+     \and{Q0} (
+       \equals{SortBool{}, Q0}(@VarB:SortBool{},\dv{SortBool{}}("false")),
+        \top{Q0}())))
+  [UNIQUE'Unds'ID{}("ff38a911e0bfd4c9765658dd908e0ef2ceee912f22703ddb571af28ef362bc9e"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1157,8,1157,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), sortParams{}("{Q0}")]
+
+// rule #Equals{Bool,#SortParam}(#token("false","Bool"),`_=/=Int_`(K1,K2))=>#Equals{Int,#SortParam}(K1,K2) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(d7c9cbef16213d5e4080a42fb2a09667bd1c8938cf3c53435e59f29a08840af3), org.kframework.attributes.Location(Location(1405,8,1405,55)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, sortParams({Q0})]
+  axiom{R,Q0} \implies{R} (
+    \top{R}(),
+    \equals{Q0,R} (
+      \equals{SortBool{}, Q0}(\dv{SortBool{}}("false"),Lbl'UndsEqlsSlshEqls'Int'Unds'{}(VarK1:SortInt{},VarK2:SortInt{})),
+     \and{Q0} (
+       \equals{SortInt{}, Q0}(VarK1:SortInt{},VarK2:SortInt{}),
+        \top{Q0}())))
+  [UNIQUE'Unds'ID{}("d7c9cbef16213d5e4080a42fb2a09667bd1c8938cf3c53435e59f29a08840af3"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1405,8,1405,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), sortParams{}("{Q0}")]
+
+// rule #Equals{Bool,#SortParam}(#token("false","Bool"),`_=/=K_`(K1,K2))=>#Equals{K,#SortParam}(K1,K2) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(8c3adbcee5cba3c9dba97d0b267b9589c7960c2c903190cb69f6d94ea1fbdd75), org.kframework.attributes.Location(Location(2280,8,2280,53)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, sortParams({Q0})]
+  axiom{R,Q0} \implies{R} (
+    \top{R}(),
+    \equals{Q0,R} (
+      \equals{SortBool{}, Q0}(\dv{SortBool{}}("false"),Lbl'UndsEqlsSlshEqls'K'Unds'{}(VarK1:SortK{},VarK2:SortK{})),
+     \and{Q0} (
+       \equals{SortK{}, Q0}(VarK1:SortK{},VarK2:SortK{}),
+        \top{Q0}())))
+  [UNIQUE'Unds'ID{}("8c3adbcee5cba3c9dba97d0b267b9589c7960c2c903190cb69f6d94ea1fbdd75"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2280,8,2280,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), sortParams{}("{Q0}")]
+
+// rule #Equals{Bool,#SortParam}(#token("false","Bool"),`_==Int_`(K1,K2))=>#Not{#SortParam}(#Equals{Int,#SortParam}(K1,K2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(c7c52e8d084d36a80f6e3cde653e5611142b9a1f73dfa4281eacb201c7e61a6f), org.kframework.attributes.Location(Location(1401,8,1401,60)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, sortParams({Q0})]
+  axiom{R,Q0} \implies{R} (
+    \top{R}(),
+    \equals{Q0,R} (
+      \equals{SortBool{}, Q0}(\dv{SortBool{}}("false"),Lbl'UndsEqlsEqls'Int'Unds'{}(VarK1:SortInt{},VarK2:SortInt{})),
+     \and{Q0} (
+       \not{Q0}(\equals{SortInt{}, Q0}(VarK1:SortInt{},VarK2:SortInt{})),
+        \top{Q0}())))
+  [UNIQUE'Unds'ID{}("c7c52e8d084d36a80f6e3cde653e5611142b9a1f73dfa4281eacb201c7e61a6f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1401,8,1401,60)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), sortParams{}("{Q0}")]
+
+// rule #Equals{Bool,#SortParam}(#token("false","Bool"),`_==K_`(K1,K2))=>#Not{#SortParam}(#Equals{K,#SortParam}(K1,K2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(074355783c5651a021ad5e253782bea2ebbab652b3e80d5516eed89f9e435dda), org.kframework.attributes.Location(Location(2276,8,2276,58)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, sortParams({Q0})]
+  axiom{R,Q0} \implies{R} (
+    \top{R}(),
+    \equals{Q0,R} (
+      \equals{SortBool{}, Q0}(\dv{SortBool{}}("false"),Lbl'UndsEqlsEqls'K'Unds'{}(VarK1:SortK{},VarK2:SortK{})),
+     \and{Q0} (
+       \not{Q0}(\equals{SortK{}, Q0}(VarK1:SortK{},VarK2:SortK{})),
+        \top{Q0}())))
+  [UNIQUE'Unds'ID{}("074355783c5651a021ad5e253782bea2ebbab652b3e80d5516eed89f9e435dda"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2276,8,2276,58)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), sortParams{}("{Q0}")]
+
+// rule #Equals{Bool,#SortParam}(#token("false","Bool"),`_orBool_`(@B1,@B2))=>#And{#SortParam}(#Equals{Bool,#SortParam}(#token("false","Bool"),@B1),#Equals{Bool,#SortParam}(#token("false","Bool"),@B2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(d58ed383e30c685252b6208bcbaa2c5a6d2bb2c61866156cd5f5496203452471), org.kframework.attributes.Location(Location(1163,8,1163,86)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, sortParams({Q0})]
+  axiom{R,Q0} \implies{R} (
+    \top{R}(),
+    \equals{Q0,R} (
+      \equals{SortBool{}, Q0}(\dv{SortBool{}}("false"),Lbl'Unds'orBool'Unds'{}(@VarB1:SortBool{},@VarB2:SortBool{})),
+     \and{Q0} (
+       \and{Q0}(\equals{SortBool{}, Q0}(\dv{SortBool{}}("false"),@VarB1:SortBool{}),\equals{SortBool{}, Q0}(\dv{SortBool{}}("false"),@VarB2:SortBool{})),
+        \top{Q0}())))
+  [UNIQUE'Unds'ID{}("d58ed383e30c685252b6208bcbaa2c5a6d2bb2c61866156cd5f5496203452471"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1163,8,1163,86)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), sortParams{}("{Q0}")]
+
+// rule #Equals{Bool,#SortParam}(#token("false","Bool"),`notBool_`(@B))=>#Equals{Bool,#SortParam}(#token("true","Bool"),@B) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(41cf8859c3dd6d6cb8f0d5950f13eda843cb8f3a234f96f288ac0443685d67e6), org.kframework.attributes.Location(Location(1158,8,1158,55)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, sortParams({Q0})]
+  axiom{R,Q0} \implies{R} (
+    \top{R}(),
+    \equals{Q0,R} (
+      \equals{SortBool{}, Q0}(\dv{SortBool{}}("false"),LblnotBool'Unds'{}(@VarB:SortBool{})),
+     \and{Q0} (
+       \equals{SortBool{}, Q0}(\dv{SortBool{}}("true"),@VarB:SortBool{}),
+        \top{Q0}())))
+  [UNIQUE'Unds'ID{}("41cf8859c3dd6d6cb8f0d5950f13eda843cb8f3a234f96f288ac0443685d67e6"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1158,8,1158,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), sortParams{}("{Q0}")]
+
+// rule #Equals{Bool,#SortParam}(#token("true","Bool"),`_=/=Int_`(K1,K2))=>#Not{#SortParam}(#Equals{Int,#SortParam}(K1,K2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(dfa307a5e907cea86327028760f87f409e66628e90f2c249c7604c7c4a1075c9), org.kframework.attributes.Location(Location(1403,8,1403,60)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, sortParams({Q0})]
+  axiom{R,Q0} \implies{R} (
+    \top{R}(),
+    \equals{Q0,R} (
+      \equals{SortBool{}, Q0}(\dv{SortBool{}}("true"),Lbl'UndsEqlsSlshEqls'Int'Unds'{}(VarK1:SortInt{},VarK2:SortInt{})),
+     \and{Q0} (
+       \not{Q0}(\equals{SortInt{}, Q0}(VarK1:SortInt{},VarK2:SortInt{})),
+        \top{Q0}())))
+  [UNIQUE'Unds'ID{}("dfa307a5e907cea86327028760f87f409e66628e90f2c249c7604c7c4a1075c9"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1403,8,1403,60)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), sortParams{}("{Q0}")]
+
+// rule #Equals{Bool,#SortParam}(#token("true","Bool"),`_=/=K_`(K1,K2))=>#Not{#SortParam}(#Equals{K,#SortParam}(K1,K2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4bb5613968e43b08303fdbbe2dd22b6186c92b98ef7b9cb3c7f1f46ee17d91a6), org.kframework.attributes.Location(Location(2278,8,2278,58)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, sortParams({Q0})]
+  axiom{R,Q0} \implies{R} (
+    \top{R}(),
+    \equals{Q0,R} (
+      \equals{SortBool{}, Q0}(\dv{SortBool{}}("true"),Lbl'UndsEqlsSlshEqls'K'Unds'{}(VarK1:SortK{},VarK2:SortK{})),
+     \and{Q0} (
+       \not{Q0}(\equals{SortK{}, Q0}(VarK1:SortK{},VarK2:SortK{})),
+        \top{Q0}())))
+  [UNIQUE'Unds'ID{}("4bb5613968e43b08303fdbbe2dd22b6186c92b98ef7b9cb3c7f1f46ee17d91a6"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2278,8,2278,58)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), sortParams{}("{Q0}")]
+
+// rule #Equals{Bool,#SortParam}(#token("true","Bool"),`_==Int_`(K1,K2))=>#Equals{Int,#SortParam}(K1,K2) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(8cca279825f2643425a59b2b4604747f38b6c33ee61380f6c2bf438632b28511), org.kframework.attributes.Location(Location(1399,8,1399,53)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, sortParams({Q0})]
+  axiom{R,Q0} \implies{R} (
+    \top{R}(),
+    \equals{Q0,R} (
+      \equals{SortBool{}, Q0}(\dv{SortBool{}}("true"),Lbl'UndsEqlsEqls'Int'Unds'{}(VarK1:SortInt{},VarK2:SortInt{})),
+     \and{Q0} (
+       \equals{SortInt{}, Q0}(VarK1:SortInt{},VarK2:SortInt{}),
+        \top{Q0}())))
+  [UNIQUE'Unds'ID{}("8cca279825f2643425a59b2b4604747f38b6c33ee61380f6c2bf438632b28511"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1399,8,1399,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), sortParams{}("{Q0}")]
+
+// rule #Equals{Bool,#SortParam}(#token("true","Bool"),`_==K_`(K1,K2))=>#Equals{K,#SortParam}(K1,K2) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(ec5382e5e3ff3234e9ad938d6fbc2b7fbf9b88bd8c3d5b52ba6d9e54c93bb323), org.kframework.attributes.Location(Location(2274,8,2274,51)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, sortParams({Q0})]
+  axiom{R,Q0} \implies{R} (
+    \top{R}(),
+    \equals{Q0,R} (
+      \equals{SortBool{}, Q0}(\dv{SortBool{}}("true"),Lbl'UndsEqlsEqls'K'Unds'{}(VarK1:SortK{},VarK2:SortK{})),
+     \and{Q0} (
+       \equals{SortK{}, Q0}(VarK1:SortK{},VarK2:SortK{}),
+        \top{Q0}())))
+  [UNIQUE'Unds'ID{}("ec5382e5e3ff3234e9ad938d6fbc2b7fbf9b88bd8c3d5b52ba6d9e54c93bb323"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2274,8,2274,51)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), sortParams{}("{Q0}")]
+
+// rule #Equals{Bool,#SortParam}(#token("true","Bool"),`_andBool_`(@B1,@B2))=>#And{#SortParam}(#Equals{Bool,#SortParam}(#token("true","Bool"),@B1),#Equals{Bool,#SortParam}(#token("true","Bool"),@B2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(b87686476d42cb8b71543b0942857bf74e4e1f49c62efe4f060a06e0cc2d53fb), org.kframework.attributes.Location(Location(1161,8,1161,84)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, sortParams({Q0})]
+  axiom{R,Q0} \implies{R} (
+    \top{R}(),
+    \equals{Q0,R} (
+      \equals{SortBool{}, Q0}(\dv{SortBool{}}("true"),Lbl'Unds'andBool'Unds'{}(@VarB1:SortBool{},@VarB2:SortBool{})),
+     \and{Q0} (
+       \and{Q0}(\equals{SortBool{}, Q0}(\dv{SortBool{}}("true"),@VarB1:SortBool{}),\equals{SortBool{}, Q0}(\dv{SortBool{}}("true"),@VarB2:SortBool{})),
+        \top{Q0}())))
+  [UNIQUE'Unds'ID{}("b87686476d42cb8b71543b0942857bf74e4e1f49c62efe4f060a06e0cc2d53fb"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1161,8,1161,84)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), sortParams{}("{Q0}")]
+
+// rule #Equals{Bool,#SortParam}(#token("true","Bool"),`notBool_`(@B))=>#Equals{Bool,#SortParam}(#token("false","Bool"),@B) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2c40c69936606d292ca999440716bfe9b6421a9e4a182731b8881126a2dc8e2f), org.kframework.attributes.Location(Location(1156,8,1156,55)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, sortParams({Q0})]
+  axiom{R,Q0} \implies{R} (
+    \top{R}(),
+    \equals{Q0,R} (
+      \equals{SortBool{}, Q0}(\dv{SortBool{}}("true"),LblnotBool'Unds'{}(@VarB:SortBool{})),
+     \and{Q0} (
+       \equals{SortBool{}, Q0}(\dv{SortBool{}}("false"),@VarB:SortBool{}),
+        \top{Q0}())))
+  [UNIQUE'Unds'ID{}("2c40c69936606d292ca999440716bfe9b6421a9e4a182731b8881126a2dc8e2f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1156,8,1156,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), sortParams{}("{Q0}")]
+
+// rule `#if_#then_#else_#fi_K-EQUAL-SYNTAX_Sort_Bool_Sort_Sort`{K}(C,B1,_Gen0)=>B1 requires C ensures #token("true","Bool") [UNIQUE_ID(2b32069ac3f589174502fa507ebc88fab7c902854c0a9baa8ab09beb551232e2), org.kframework.attributes.Location(Location(2291,8,2291,59)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        VarC:SortBool{},
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarC:SortBool{}
+          ),\and{R} (
+          \in{SortK{}, R} (
+            X1:SortK{},
+            VarB1:SortK{}
+          ),\and{R} (
+          \in{SortK{}, R} (
+            X2:SortK{},
+            Var'Unds'Gen0:SortK{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortK{},R} (
+      Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL-SYNTAX'Unds'Sort'Unds'Bool'Unds'Sort'Unds'Sort{SortK{}}(X0:SortBool{},X1:SortK{},X2:SortK{}),
+     \and{SortK{}} (
+       VarB1:SortK{},
+        \top{SortK{}}())))
+  [UNIQUE'Unds'ID{}("2b32069ac3f589174502fa507ebc88fab7c902854c0a9baa8ab09beb551232e2"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2291,8,2291,59)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]")]
+
+// rule `#if_#then_#else_#fi_K-EQUAL-SYNTAX_Sort_Bool_Sort_Sort`{K}(C,_Gen0,B2)=>B2 requires `notBool_`(C) ensures #token("true","Bool") [UNIQUE_ID(651bff3fa53d464ac7dd7aa77e1ef6071e14c959eb6df97baa325e2ad300daaa), org.kframework.attributes.Location(Location(2292,8,2292,67)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        LblnotBool'Unds'{}(VarC:SortBool{}),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarC:SortBool{}
+          ),\and{R} (
+          \in{SortK{}, R} (
+            X1:SortK{},
+            Var'Unds'Gen0:SortK{}
+          ),\and{R} (
+          \in{SortK{}, R} (
+            X2:SortK{},
+            VarB2:SortK{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortK{},R} (
+      Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL-SYNTAX'Unds'Sort'Unds'Bool'Unds'Sort'Unds'Sort{SortK{}}(X0:SortBool{},X1:SortK{},X2:SortK{}),
+     \and{SortK{}} (
+       VarB2:SortK{},
+        \top{SortK{}}())))
+  [UNIQUE'Unds'ID{}("651bff3fa53d464ac7dd7aa77e1ef6071e14c959eb6df97baa325e2ad300daaa"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2292,8,2292,67)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]")]
+
+// rule `_%Int_`(X,N)=>X requires `_andBool_`(`_<=Int_`(#token("0","Int"),X),`_<Int_`(X,N)) ensures #token("true","Bool") [UNIQUE_ID(3c6a6ed93c91491e78006950a229b91fe57edd207091cb418b88655e3af66f94), org.kframework.attributes.Location(Location(1353,8,1353,59)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol]), simplification]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'Unds'andBool'Unds'{}(Lbl'Unds-LT-Eqls'Int'Unds'{}(\dv{SortInt{}}("0"),VarX:SortInt{}),Lbl'Unds-LT-'Int'Unds'{}(VarX:SortInt{},VarN:SortInt{})),
+        \dv{SortBool{}}("true")),
+    \equals{SortInt{},R} (
+      Lbl'UndsPerc'Int'Unds'{}(VarX:SortInt{},VarN:SortInt{}),
+     \and{SortInt{}} (
+       VarX:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("3c6a6ed93c91491e78006950a229b91fe57edd207091cb418b88655e3af66f94"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1353,8,1353,59)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), simplification{}("")]
+
+// rule `_&Int_`(I1,`_&Int_`(I2,C))=>`_&Int_`(`_&Int_`(I1,I2),C) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(1b7de709091a3290862d7a9ca2625659b666b89c5a3b27bdfee178b1628fd179), concrete(I1, I2), org.kframework.attributes.Location(Location(1388,8,1388,50)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, symbolic(C)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortInt{},R} (
+      Lbl'UndsAnd-'Int'Unds'{}(VarI1:SortInt{},Lbl'UndsAnd-'Int'Unds'{}(VarI2:SortInt{},VarC:SortInt{})),
+     \and{SortInt{}} (
+       Lbl'UndsAnd-'Int'Unds'{}(Lbl'UndsAnd-'Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{}),VarC:SortInt{}),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("1b7de709091a3290862d7a9ca2625659b666b89c5a3b27bdfee178b1628fd179"), concrete{}(VarI1:SortInt{},VarI2:SortInt{}), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1388,8,1388,50)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), symbolic{}(VarC:SortInt{})]
+
+// rule `_+Int_`(I,B)=>`_+Int_`(B,I) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f414cbac7ca5c0f2f75da04135615fea6af0646bed9962865d7b02a45901a09b), concrete(I), org.kframework.attributes.Location(Location(1375,8,1375,28)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification(51), symbolic(B)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortInt{},R} (
+      Lbl'UndsPlus'Int'Unds'{}(VarI:SortInt{},VarB:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'UndsPlus'Int'Unds'{}(VarB:SortInt{},VarI:SortInt{}),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("f414cbac7ca5c0f2f75da04135615fea6af0646bed9962865d7b02a45901a09b"), concrete{}(VarI:SortInt{}), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1375,8,1375,28)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}("51"), symbolic{}(VarB:SortInt{})]
+
+// rule `_+Int_`(I,#token("0","Int"))=>I requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(d8b4ae4926d8ec7b1d5abaa5fed68fd6c7f3f5a21c76a51231394a2b36fbf995), org.kframework.attributes.Location(Location(1349,8,1349,21)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortInt{},R} (
+      Lbl'UndsPlus'Int'Unds'{}(VarI:SortInt{},\dv{SortInt{}}("0")),
+     \and{SortInt{}} (
+       VarI:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("d8b4ae4926d8ec7b1d5abaa5fed68fd6c7f3f5a21c76a51231394a2b36fbf995"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1349,8,1349,21)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}("")]
+
+// rule `_+Int_`(I1,`_+Int_`(B,I3))=>`_+Int_`(B,`_+Int_`(I1,I3)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(268b9a7c15e96c6d7eca16bc9022dc880f06a15ca8018eb1854b9836fc3e965c), concrete(I1, I3), org.kframework.attributes.Location(Location(1379,8,1379,50)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, symbolic(B)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortInt{},R} (
+      Lbl'UndsPlus'Int'Unds'{}(VarI1:SortInt{},Lbl'UndsPlus'Int'Unds'{}(VarB:SortInt{},VarI3:SortInt{})),
+     \and{SortInt{}} (
+       Lbl'UndsPlus'Int'Unds'{}(VarB:SortInt{},Lbl'UndsPlus'Int'Unds'{}(VarI1:SortInt{},VarI3:SortInt{})),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("268b9a7c15e96c6d7eca16bc9022dc880f06a15ca8018eb1854b9836fc3e965c"), concrete{}(VarI1:SortInt{},VarI3:SortInt{}), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1379,8,1379,50)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), symbolic{}(VarB:SortInt{})]
+
+// rule `_+Int_`(I1,`_+Int_`(I2,C))=>`_+Int_`(`_+Int_`(I1,I2),C) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(945eee1b50c7ee86f3997715061349a7d77bf7ede65b292713da34b6ba2e568e), concrete(I1, I2), org.kframework.attributes.Location(Location(1381,8,1381,50)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, symbolic(C)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortInt{},R} (
+      Lbl'UndsPlus'Int'Unds'{}(VarI1:SortInt{},Lbl'UndsPlus'Int'Unds'{}(VarI2:SortInt{},VarC:SortInt{})),
+     \and{SortInt{}} (
+       Lbl'UndsPlus'Int'Unds'{}(Lbl'UndsPlus'Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{}),VarC:SortInt{}),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("945eee1b50c7ee86f3997715061349a7d77bf7ede65b292713da34b6ba2e568e"), concrete{}(VarI1:SortInt{},VarI2:SortInt{}), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1381,8,1381,50)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), symbolic{}(VarC:SortInt{})]
+
+// rule `_+Int_`(I1,`_-Int_`(I2,C))=>`_-Int_`(`_+Int_`(I1,I2),C) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(3f8e2290240b516c1395fc1e6f038dc63b8fe27951133eb2a64b65a0d71e1cf1), concrete(I1, I2), org.kframework.attributes.Location(Location(1382,8,1382,50)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, symbolic(C)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortInt{},R} (
+      Lbl'UndsPlus'Int'Unds'{}(VarI1:SortInt{},Lbl'Unds'-Int'Unds'{}(VarI2:SortInt{},VarC:SortInt{})),
+     \and{SortInt{}} (
+       Lbl'Unds'-Int'Unds'{}(Lbl'UndsPlus'Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{}),VarC:SortInt{}),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("3f8e2290240b516c1395fc1e6f038dc63b8fe27951133eb2a64b65a0d71e1cf1"), concrete{}(VarI1:SortInt{},VarI2:SortInt{}), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1382,8,1382,50)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), symbolic{}(VarC:SortInt{})]
+
+// rule `_+Int_`(`_+Int_`(A,I2),I3)=>`_+Int_`(A,`_+Int_`(I2,I3)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(bd1f111a70bb9802e01754c9b95e7bbc5e924e2cd3749d93c73a02b7d01377a9), concrete(I2, I3), org.kframework.attributes.Location(Location(1378,8,1378,50)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, symbolic(A)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortInt{},R} (
+      Lbl'UndsPlus'Int'Unds'{}(Lbl'UndsPlus'Int'Unds'{}(VarA:SortInt{},VarI2:SortInt{}),VarI3:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'UndsPlus'Int'Unds'{}(VarA:SortInt{},Lbl'UndsPlus'Int'Unds'{}(VarI2:SortInt{},VarI3:SortInt{})),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("bd1f111a70bb9802e01754c9b95e7bbc5e924e2cd3749d93c73a02b7d01377a9"), concrete{}(VarI2:SortInt{},VarI3:SortInt{}), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1378,8,1378,50)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), symbolic{}(VarA:SortInt{})]
+
+// rule `_+Int_`(`_-Int_`(I1,B),I3)=>`_-Int_`(`_+Int_`(I1,I3),B) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(a0ccce19dfe6142c052181702bc6afa92bef00189634e2cd81e3df72d18b6f72), concrete(I1, I3), org.kframework.attributes.Location(Location(1383,8,1383,50)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, symbolic(B)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortInt{},R} (
+      Lbl'UndsPlus'Int'Unds'{}(Lbl'Unds'-Int'Unds'{}(VarI1:SortInt{},VarB:SortInt{}),VarI3:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'Unds'-Int'Unds'{}(Lbl'UndsPlus'Int'Unds'{}(VarI1:SortInt{},VarI3:SortInt{}),VarB:SortInt{}),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("a0ccce19dfe6142c052181702bc6afa92bef00189634e2cd81e3df72d18b6f72"), concrete{}(VarI1:SortInt{},VarI3:SortInt{}), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1383,8,1383,50)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), symbolic{}(VarB:SortInt{})]
+
+// rule `_-Int_`(A,I)=>`_+Int_`(A,`_-Int_`(#token("0","Int"),I)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5006e67cf607e7b0d114a5cf79189eef34941e4c1136f2bcfa0ecb4a5f409aaa), concrete(I), org.kframework.attributes.Location(Location(1376,8,1376,37)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification(51), symbolic(A)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortInt{},R} (
+      Lbl'Unds'-Int'Unds'{}(VarA:SortInt{},VarI:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'UndsPlus'Int'Unds'{}(VarA:SortInt{},Lbl'Unds'-Int'Unds'{}(\dv{SortInt{}}("0"),VarI:SortInt{})),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("5006e67cf607e7b0d114a5cf79189eef34941e4c1136f2bcfa0ecb4a5f409aaa"), concrete{}(VarI:SortInt{}), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1376,8,1376,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}("51"), symbolic{}(VarA:SortInt{})]
+
+// rule `_-Int_`(I,#token("0","Int"))=>I requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(d86d26d8f81aca004f9bc8ad3e99c8c73cbf1c3dd4c60d3f44c3a524af1dff49), org.kframework.attributes.Location(Location(1350,8,1350,21)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortInt{},R} (
+      Lbl'Unds'-Int'Unds'{}(VarI:SortInt{},\dv{SortInt{}}("0")),
+     \and{SortInt{}} (
+       VarI:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("d86d26d8f81aca004f9bc8ad3e99c8c73cbf1c3dd4c60d3f44c3a524af1dff49"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1350,8,1350,21)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}("")]
+
+// rule `_-Int_`(I1,`_+Int_`(B,I3))=>`_-Int_`(`_-Int_`(I1,I3),B) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f3dfc3d737ef13caec61d97df64b52c7385de0bdcbe1ad7df52e5782b021d3bc), concrete(I1, I3), org.kframework.attributes.Location(Location(1380,8,1380,50)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, symbolic(B)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortInt{},R} (
+      Lbl'Unds'-Int'Unds'{}(VarI1:SortInt{},Lbl'UndsPlus'Int'Unds'{}(VarB:SortInt{},VarI3:SortInt{})),
+     \and{SortInt{}} (
+       Lbl'Unds'-Int'Unds'{}(Lbl'Unds'-Int'Unds'{}(VarI1:SortInt{},VarI3:SortInt{}),VarB:SortInt{}),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("f3dfc3d737ef13caec61d97df64b52c7385de0bdcbe1ad7df52e5782b021d3bc"), concrete{}(VarI1:SortInt{},VarI3:SortInt{}), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1380,8,1380,50)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), symbolic{}(VarB:SortInt{})]
+
+// rule `_-Int_`(I1,`_+Int_`(I2,C))=>`_-Int_`(`_-Int_`(I1,I2),C) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(40f6808fcbd77c0ad816055dc5c3128e2140c47840910c8141267828c3289f60), concrete(I1, I2), org.kframework.attributes.Location(Location(1384,8,1384,50)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, symbolic(C)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortInt{},R} (
+      Lbl'Unds'-Int'Unds'{}(VarI1:SortInt{},Lbl'UndsPlus'Int'Unds'{}(VarI2:SortInt{},VarC:SortInt{})),
+     \and{SortInt{}} (
+       Lbl'Unds'-Int'Unds'{}(Lbl'Unds'-Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{}),VarC:SortInt{}),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("40f6808fcbd77c0ad816055dc5c3128e2140c47840910c8141267828c3289f60"), concrete{}(VarI1:SortInt{},VarI2:SortInt{}), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1384,8,1384,50)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), symbolic{}(VarC:SortInt{})]
+
+// rule `_-Int_`(I1,`_-Int_`(I2,C))=>`_+Int_`(`_-Int_`(I1,I2),C) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(1c038450af0ca2c7dbe53cab1a50de6a5afebca70825506f82586b79697c8685), concrete(I1, I2), org.kframework.attributes.Location(Location(1385,8,1385,50)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, symbolic(C)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortInt{},R} (
+      Lbl'Unds'-Int'Unds'{}(VarI1:SortInt{},Lbl'Unds'-Int'Unds'{}(VarI2:SortInt{},VarC:SortInt{})),
+     \and{SortInt{}} (
+       Lbl'UndsPlus'Int'Unds'{}(Lbl'Unds'-Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{}),VarC:SortInt{}),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("1c038450af0ca2c7dbe53cab1a50de6a5afebca70825506f82586b79697c8685"), concrete{}(VarI1:SortInt{},VarI2:SortInt{}), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1385,8,1385,50)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), symbolic{}(VarC:SortInt{})]
+
+// rule `_-Int_`(`_-Int_`(C,I2),I3)=>`_-Int_`(C,`_+Int_`(I2,I3)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2f0c45ab27fd9a31e04bd48a211c47471e15e88ed3a5ab72217ae49fc4480ba9), concrete(I2, I3), org.kframework.attributes.Location(Location(1386,8,1386,50)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification, symbolic(C)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortInt{},R} (
+      Lbl'Unds'-Int'Unds'{}(Lbl'Unds'-Int'Unds'{}(VarC:SortInt{},VarI2:SortInt{}),VarI3:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'Unds'-Int'Unds'{}(VarC:SortInt{},Lbl'UndsPlus'Int'Unds'{}(VarI2:SortInt{},VarI3:SortInt{})),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("2f0c45ab27fd9a31e04bd48a211c47471e15e88ed3a5ab72217ae49fc4480ba9"), concrete{}(VarI2:SortInt{},VarI3:SortInt{}), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1386,8,1386,50)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}(""), symbolic{}(VarC:SortInt{})]
+
+// rule `_<<Int_`(X,#token("0","Int"))=>X requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(d9cace14bde6a604c371ca45e9ea6900a124efc18d91742ed49ef2efd97baa33), org.kframework.attributes.Location(Location(1356,8,1356,22)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortInt{},R} (
+      Lbl'Unds-LT--LT-'Int'Unds'{}(VarX:SortInt{},\dv{SortInt{}}("0")),
+     \and{SortInt{}} (
+       VarX:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("d9cace14bde6a604c371ca45e9ea6900a124efc18d91742ed49ef2efd97baa33"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1356,8,1356,22)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}("")]
+
+// rule `_<<Int_`(#token("0","Int"),_Gen0)=>#token("0","Int") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2d402e237d3a3b4ebf2358cc61e77cbb3ec03989d9be016003b2916d1935a8e9), org.kframework.attributes.Location(Location(1357,8,1357,22)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortInt{},R} (
+      Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("0"),Var'Unds'Gen0:SortInt{}),
+     \and{SortInt{}} (
+       \dv{SortInt{}}("0"),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("2d402e237d3a3b4ebf2358cc61e77cbb3ec03989d9be016003b2916d1935a8e9"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1357,8,1357,22)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}("")]
+
+// rule `_=/=Bool_`(B1,B2)=>`notBool_`(`_==Bool_`(B1,B2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(31fe72efcfddcd8588a11d9d10c1b1a9f96ae3da46b647d4cb9d1e8b1bd1654f), org.kframework.attributes.Location(Location(1150,8,1150,57)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarB1:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB2:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Bool'Unds'{}(VarB1:SortBool{},VarB2:SortBool{})),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("31fe72efcfddcd8588a11d9d10c1b1a9f96ae3da46b647d4cb9d1e8b1bd1654f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1150,8,1150,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_=/=Int_`(I1,I2)=>`notBool_`(`_==Int_`(I1,I2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4de6e05b11cdbed7ef5cb4c952127924661af4744c1e495370e1c8a962ba7be3), org.kframework.attributes.Location(Location(1431,8,1431,53)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI1:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI2:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'UndsEqlsSlshEqls'Int'Unds'{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{})),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("4de6e05b11cdbed7ef5cb4c952127924661af4744c1e495370e1c8a962ba7be3"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1431,8,1431,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_=/=K_`(K1,K2)=>`notBool_`(`_==K_`(K1,K2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(bccaba7335e4cd77501a0667f2f7b3eb4a2105d5f60d804915dd4b1b08902c0c), org.kframework.attributes.Location(Location(2289,8,2289,45)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK1:SortK{}
+          ),\and{R} (
+          \in{SortK{}, R} (
+            X1:SortK{},
+            VarK2:SortK{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'UndsEqlsSlshEqls'K'Unds'{}(X0:SortK{},X1:SortK{}),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'K'Unds'{}(VarK1:SortK{},VarK2:SortK{})),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("bccaba7335e4cd77501a0667f2f7b3eb4a2105d5f60d804915dd4b1b08902c0c"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2289,8,2289,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_==K_`(inj{Int,KItem}(I1),inj{Int,KItem}(I2))=>`_==Int_`(I1,I2) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(8bf41fa14e6cef57ebcd77d165461911b0f45874319eafd20a311466ff77ac6f), org.kframework.attributes.Location(Location(1397,8,1397,40)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'UndsEqlsEqls'K'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(VarI1:SortInt{}),dotk{}()),kseq{}(inj{SortInt{}, SortKItem{}}(VarI2:SortInt{}),dotk{}())),
+     \and{SortBool{}} (
+       Lbl'UndsEqlsEqls'Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{}),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("8bf41fa14e6cef57ebcd77d165461911b0f45874319eafd20a311466ff77ac6f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1397,8,1397,40)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}("")]
+
+// rule `_==K_`(inj{Bool,KItem}(K1),inj{Bool,KItem}(K2))=>`_==Bool_`(K1,K2) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(51ca403f7048793055685a9e3a051e86807f14b2d4901ae81d0b4eedff7b1d77), org.kframework.attributes.Location(Location(2272,8,2272,43)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'UndsEqlsEqls'K'Unds'{}(kseq{}(inj{SortBool{}, SortKItem{}}(VarK1:SortBool{}),dotk{}()),kseq{}(inj{SortBool{}, SortKItem{}}(VarK2:SortBool{}),dotk{}())),
+     \and{SortBool{}} (
+       Lbl'UndsEqlsEqls'Bool'Unds'{}(VarK1:SortBool{},VarK2:SortBool{}),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("51ca403f7048793055685a9e3a051e86807f14b2d4901ae81d0b4eedff7b1d77"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2272,8,2272,43)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}("")]
+
+// rule `_>>Int_`(X,#token("0","Int"))=>X requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(572bf49a8ddd18981c88d4573e09bebfa4ca9f0d3d1caaea04d9fa30b5d20c39), org.kframework.attributes.Location(Location(1358,8,1358,22)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortInt{},R} (
+      Lbl'Unds-GT--GT-'Int'Unds'{}(VarX:SortInt{},\dv{SortInt{}}("0")),
+     \and{SortInt{}} (
+       VarX:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("572bf49a8ddd18981c88d4573e09bebfa4ca9f0d3d1caaea04d9fa30b5d20c39"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1358,8,1358,22)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}("")]
+
+// rule `_>>Int_`(#token("0","Int"),_Gen0)=>#token("0","Int") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(1cf22edfe70c5e6f01624499522c9b110616a96e9f7894de7508ebb4a51091b9), org.kframework.attributes.Location(Location(1359,8,1359,22)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortInt{},R} (
+      Lbl'Unds-GT--GT-'Int'Unds'{}(\dv{SortInt{}}("0"),Var'Unds'Gen0:SortInt{}),
+     \and{SortInt{}} (
+       \dv{SortInt{}}("0"),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("1cf22edfe70c5e6f01624499522c9b110616a96e9f7894de7508ebb4a51091b9"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1359,8,1359,22)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}("")]
+
+// rule `_andBool_`(#token("false","Bool") #as _Gen1,_Gen0)=>_Gen1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(61fbef33b3611f1cc2aaf3b5e8ddec4a0f434c557278c38461c65c8722743497), org.kframework.attributes.Location(Location(1123,8,1123,37)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \and{SortBool{}}(\dv{SortBool{}}("false"),Var'Unds'Gen1:SortBool{})
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       Var'Unds'Gen1:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("61fbef33b3611f1cc2aaf3b5e8ddec4a0f434c557278c38461c65c8722743497"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1123,8,1123,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_andBool_`(B,#token("true","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(e8d4ca75a690151f99f8904b068db555782f5599b11230a9d0b97a71afb6fc98), org.kframework.attributes.Location(Location(1122,8,1122,37)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarB:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            \dv{SortBool{}}("true")
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("e8d4ca75a690151f99f8904b068db555782f5599b11230a9d0b97a71afb6fc98"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1122,8,1122,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_andBool_`(_Gen0,#token("false","Bool") #as _Gen1)=>_Gen1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9c183fae7de06f560180386d14d29c609cadf0c98266ce2adbecb50100a1daca), org.kframework.attributes.Location(Location(1124,8,1124,37)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            \and{SortBool{}}(\dv{SortBool{}}("false"),Var'Unds'Gen1:SortBool{})
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       Var'Unds'Gen1:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("9c183fae7de06f560180386d14d29c609cadf0c98266ce2adbecb50100a1daca"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1124,8,1124,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_andBool_`(#token("true","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5b9db8dba12010819161cc42dadccd0adf0100a47c21f884ae66c0a3d5483a1f), org.kframework.attributes.Location(Location(1121,8,1121,37)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("5b9db8dba12010819161cc42dadccd0adf0100a47c21f884ae66c0a3d5483a1f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1121,8,1121,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_andThenBool_`(#token("false","Bool") #as _Gen1,_Gen0)=>_Gen1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5b729746be7bf2183d9eff138d97078a7c9489def6d8b2e1495c41ce3954997d), org.kframework.attributes.Location(Location(1128,8,1128,36)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \and{SortBool{}}(\dv{SortBool{}}("false"),Var'Unds'Gen1:SortBool{})
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andThenBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       Var'Unds'Gen1:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("5b729746be7bf2183d9eff138d97078a7c9489def6d8b2e1495c41ce3954997d"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1128,8,1128,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_andThenBool_`(K,#token("true","Bool"))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(82ac30b094be9b12206773d87b60274e929a41ca595f4674be1d37eeff873d7c), org.kframework.attributes.Location(Location(1127,8,1127,37)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarK:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            \dv{SortBool{}}("true")
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andThenBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarK:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("82ac30b094be9b12206773d87b60274e929a41ca595f4674be1d37eeff873d7c"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1127,8,1127,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_andThenBool_`(_Gen0,#token("false","Bool") #as _Gen1)=>_Gen1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(0508592878b546cbc6eeda6ec7b322584eea5c6d6eea3f72be8418fe4f7149b2), org.kframework.attributes.Location(Location(1129,8,1129,36)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            \and{SortBool{}}(\dv{SortBool{}}("false"),Var'Unds'Gen1:SortBool{})
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andThenBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       Var'Unds'Gen1:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("0508592878b546cbc6eeda6ec7b322584eea5c6d6eea3f72be8418fe4f7149b2"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1129,8,1129,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_andThenBool_`(#token("true","Bool"),K)=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(78a3191cbbdec57b0f411f41291076c8124bb0d9b6b57905674b2c6858d78689), org.kframework.attributes.Location(Location(1126,8,1126,37)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarK:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andThenBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarK:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("78a3191cbbdec57b0f411f41291076c8124bb0d9b6b57905674b2c6858d78689"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1126,8,1126,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_divInt_`(I1,I2)=>`_/Int_`(`_-Int_`(I1,`_modInt_`(I1,I2)),I2) requires `_=/=Int_`(I2,#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(83dcf9bc8c69f131715bc7a92d06c99b9a2b5f4c4fdafb69e6fdb2f1822712d4), org.kframework.attributes.Location(Location(1420,8,1421,23)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'Int'Unds'{}(VarI2:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI1:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI2:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortInt{},R} (
+      Lbl'Unds'divInt'Unds'{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'UndsSlsh'Int'Unds'{}(Lbl'Unds'-Int'Unds'{}(VarI1:SortInt{},Lbl'Unds'modInt'Unds'{}(VarI1:SortInt{},VarI2:SortInt{})),VarI2:SortInt{}),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("83dcf9bc8c69f131715bc7a92d06c99b9a2b5f4c4fdafb69e6fdb2f1822712d4"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1420,8,1421,23)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]")]
+
+// rule `_dividesInt__INT-COMMON_Bool_Int_Int`(I1,I2)=>`_==Int_`(`_%Int_`(I2,I1),#token("0","Int")) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(fd8facae0061fe5bc5c406f7ad2ed5d8d21960bf1118c9b240451253064dadb5), org.kframework.attributes.Location(Location(1432,8,1432,58)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI1:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI2:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'dividesInt'UndsUnds'INT-COMMON'Unds'Bool'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortBool{}} (
+       Lbl'UndsEqlsEqls'Int'Unds'{}(Lbl'UndsPerc'Int'Unds'{}(VarI2:SortInt{},VarI1:SortInt{}),\dv{SortInt{}}("0")),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("fd8facae0061fe5bc5c406f7ad2ed5d8d21960bf1118c9b240451253064dadb5"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1432,8,1432,58)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_impliesBool_`(B,#token("false","Bool"))=>`notBool_`(B) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(022c562a21d72cedfb795607d2249b8ad14b66399b720b3b2f4a05a1da08df96), org.kframework.attributes.Location(Location(1148,8,1148,45)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarB:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            \dv{SortBool{}}("false")
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'impliesBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(VarB:SortBool{}),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("022c562a21d72cedfb795607d2249b8ad14b66399b720b3b2f4a05a1da08df96"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1148,8,1148,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_impliesBool_`(_Gen0,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(99ba64afc26a739953df142ccd4b486bba68107fce8c9aa356d40afa7a988712), org.kframework.attributes.Location(Location(1147,8,1147,39)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            \dv{SortBool{}}("true")
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'impliesBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("99ba64afc26a739953df142ccd4b486bba68107fce8c9aa356d40afa7a988712"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1147,8,1147,39)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_impliesBool_`(#token("false","Bool"),_Gen0)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(55bb5c83c9563c712537b95401c0a5c88255fd7cdbd18b2d4358c54aee80660e), org.kframework.attributes.Location(Location(1146,8,1146,40)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'impliesBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("55bb5c83c9563c712537b95401c0a5c88255fd7cdbd18b2d4358c54aee80660e"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1146,8,1146,40)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_impliesBool_`(#token("true","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(da818c43c21c5fb2cced7e02a74b6b4191d323de2967a671b961ad28550f3c7d), org.kframework.attributes.Location(Location(1145,8,1145,36)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'impliesBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("da818c43c21c5fb2cced7e02a74b6b4191d323de2967a671b961ad28550f3c7d"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1145,8,1145,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_modInt_`(I1,I2)=>`_%Int_`(`_+Int_`(`_%Int_`(I1,`absInt(_)_INT-COMMON_Int_Int`(I2)),`absInt(_)_INT-COMMON_Int_Int`(I2)),`absInt(_)_INT-COMMON_Int_Int`(I2)) requires `_=/=Int_`(I2,#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(adfacb58b0678a49f66186954229939a953c9849d5b08edc8f887c0d7514b2c6), concrete, org.kframework.attributes.Location(Location(1423,5,1426,23)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol]), simplification]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'Int'Unds'{}(VarI2:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \equals{SortInt{},R} (
+      Lbl'Unds'modInt'Unds'{}(VarI1:SortInt{},VarI2:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'UndsPerc'Int'Unds'{}(Lbl'UndsPlus'Int'Unds'{}(Lbl'UndsPerc'Int'Unds'{}(VarI1:SortInt{},LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(VarI2:SortInt{})),LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(VarI2:SortInt{})),LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(VarI2:SortInt{})),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("adfacb58b0678a49f66186954229939a953c9849d5b08edc8f887c0d7514b2c6"), concrete{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1423,5,1426,23)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), simplification{}("")]
+
+// rule `_modInt_`(X,N)=>X requires `_andBool_`(`_<=Int_`(#token("0","Int"),X),`_<Int_`(X,N)) ensures #token("true","Bool") [UNIQUE_ID(3a397a001af2fcd0eaf3c29fa026cf37c07fb9b8d6245bae8906780b5e74f503), org.kframework.attributes.Location(Location(1352,8,1352,59)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol]), simplification]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'Unds'andBool'Unds'{}(Lbl'Unds-LT-Eqls'Int'Unds'{}(\dv{SortInt{}}("0"),VarX:SortInt{}),Lbl'Unds-LT-'Int'Unds'{}(VarX:SortInt{},VarN:SortInt{})),
+        \dv{SortBool{}}("true")),
+    \equals{SortInt{},R} (
+      Lbl'Unds'modInt'Unds'{}(VarX:SortInt{},VarN:SortInt{}),
+     \and{SortInt{}} (
+       VarX:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("3a397a001af2fcd0eaf3c29fa026cf37c07fb9b8d6245bae8906780b5e74f503"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1352,8,1352,59)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), simplification{}("")]
+
+// rule `_orBool_`(B,#token("false","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(d7245713da157cf997438091f92bb78eb51a6cefa568bb0d30560ce08d647f26), org.kframework.attributes.Location(Location(1138,8,1138,32)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarB:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            \dv{SortBool{}}("false")
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("d7245713da157cf997438091f92bb78eb51a6cefa568bb0d30560ce08d647f26"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1138,8,1138,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_orBool_`(_Gen0,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(47860d52c18a441b229449cd89d5464256137dc32deb5551effbac0482c883f3), org.kframework.attributes.Location(Location(1136,8,1136,34)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            \dv{SortBool{}}("true")
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("47860d52c18a441b229449cd89d5464256137dc32deb5551effbac0482c883f3"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1136,8,1136,34)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_orBool_`(#token("false","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(991a3290bc7b6dca75d676a72a848ec6b2bd2827fb0e9626252aa1507394ca1b), org.kframework.attributes.Location(Location(1137,8,1137,32)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("991a3290bc7b6dca75d676a72a848ec6b2bd2827fb0e9626252aa1507394ca1b"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1137,8,1137,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_orBool_`(#token("true","Bool"),_Gen0)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(71744528cdad83bc729990d3af3b544d27b09630b2615ca707dd2fc6ec93e7c2), org.kframework.attributes.Location(Location(1135,8,1135,34)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("71744528cdad83bc729990d3af3b544d27b09630b2615ca707dd2fc6ec93e7c2"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1135,8,1135,34)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_orElseBool_`(K,#token("false","Bool"))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(684b0444a1f711d49ff1502423a3346fb26958697423db488b05d25081fc0480), org.kframework.attributes.Location(Location(1143,8,1143,37)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarK:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            \dv{SortBool{}}("false")
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orElseBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarK:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("684b0444a1f711d49ff1502423a3346fb26958697423db488b05d25081fc0480"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1143,8,1143,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_orElseBool_`(_Gen0,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(c9eccff94ecf6e810c600d4536bf1701485c13c3456c6b98c0cdab0fe7c5af14), org.kframework.attributes.Location(Location(1141,8,1141,33)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            \dv{SortBool{}}("true")
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orElseBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("c9eccff94ecf6e810c600d4536bf1701485c13c3456c6b98c0cdab0fe7c5af14"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1141,8,1141,33)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_orElseBool_`(#token("false","Bool"),K)=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(eb8c85dac19a5951f694b65269c2b17c80d6d126d6a367958e4a5d736a880ecf), org.kframework.attributes.Location(Location(1142,8,1142,37)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarK:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orElseBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarK:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("eb8c85dac19a5951f694b65269c2b17c80d6d126d6a367958e4a5d736a880ecf"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1142,8,1142,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_orElseBool_`(#token("true","Bool"),_Gen0)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(354bd0860c7f38b59e285c935fd2ea553ebddbabb4973342ad25f0dac6ea7bf6), org.kframework.attributes.Location(Location(1140,8,1140,33)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orElseBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("354bd0860c7f38b59e285c935fd2ea553ebddbabb4973342ad25f0dac6ea7bf6"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1140,8,1140,33)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_xorBool_`(B,B)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9a6d91cd75cd777b0d4db536b3e4b20578e74fe650e644b55294da95fd2dba7f), org.kframework.attributes.Location(Location(1133,8,1133,38)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarB:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'xorBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("9a6d91cd75cd777b0d4db536b3e4b20578e74fe650e644b55294da95fd2dba7f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1133,8,1133,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_xorBool_`(B,#token("false","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7a2851f9d4ea4bd3f35070ee029fc3bdca36e361f7ee54addeff9d10ddeb7c75), org.kframework.attributes.Location(Location(1132,8,1132,38)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarB:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            \dv{SortBool{}}("false")
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'xorBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("7a2851f9d4ea4bd3f35070ee029fc3bdca36e361f7ee54addeff9d10ddeb7c75"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1132,8,1132,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_xorBool_`(#token("false","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(73513655c09a595907ab9d26d67e27f01d14a3435743b77000c02d10f35c05bf), org.kframework.attributes.Location(Location(1131,8,1131,38)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'xorBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("73513655c09a595907ab9d26d67e27f01d14a3435743b77000c02d10f35c05bf"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1131,8,1131,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_|Set__SET_Set_Set_Set`(S1,S2)=>`_Set_`(S1,`Set:difference`(S2,S1)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(e9a710d8d1ca5c799420161879cbbff926de45a5bddd820d646f51d43eb67e62), concrete, org.kframework.attributes.Location(Location(749,8,749,45)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortSet{}, R} (
+            X0:SortSet{},
+            VarS1:SortSet{}
+          ),\and{R} (
+          \in{SortSet{}, R} (
+            X1:SortSet{},
+            VarS2:SortSet{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortSet{},R} (
+      Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(X0:SortSet{},X1:SortSet{}),
+     \and{SortSet{}} (
+       Lbl'Unds'Set'Unds'{}(VarS1:SortSet{},LblSet'Coln'difference{}(VarS2:SortSet{},VarS1:SortSet{})),
+        \top{SortSet{}}())))
+  [UNIQUE'Unds'ID{}("e9a710d8d1ca5c799420161879cbbff926de45a5bddd820d646f51d43eb67e62"), concrete{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(749,8,749,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `bitRangeInt(_,_,_)_INT-COMMON_Int_Int_Int_Int`(I,IDX,LEN)=>`_modInt_`(`_>>Int_`(I,IDX),`_<<Int_`(#token("1","Int"),LEN)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(147fc15c2ec6c36de1a9c0cad6212b8acd8b224f21c0aeabd36726e9c8a06119), org.kframework.attributes.Location(Location(1416,8,1416,85)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarIDX:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X2:SortInt{},
+            VarLEN:SortInt{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortInt{},R} (
+      LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{},X2:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'Unds'modInt'Unds'{}(Lbl'Unds-GT--GT-'Int'Unds'{}(VarI:SortInt{},VarIDX:SortInt{}),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),VarLEN:SortInt{})),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("147fc15c2ec6c36de1a9c0cad6212b8acd8b224f21c0aeabd36726e9c8a06119"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1416,8,1416,85)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `freshInt(_)_INT_Int_Int`(I)=>I requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(cf2cb8f038b4bdc4edb1334a3b8ced9cd296a7af43f0a1916e082a4e1aefa08b), org.kframework.attributes.Location(Location(1435,8,1435,28)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI:SortInt{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortInt{},R} (
+      LblfreshInt'LParUndsRParUnds'INT'Unds'Int'Unds'Int{}(X0:SortInt{}),
+     \and{SortInt{}} (
+       VarI:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("cf2cb8f038b4bdc4edb1334a3b8ced9cd296a7af43f0a1916e082a4e1aefa08b"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1435,8,1435,28)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule getGeneratedCounterCell(`<generatedTop>`(_DotVar0,Cell))=>Cell requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9ef5eb9b9e6bbd7436911fad20615821f61e06e742dd27773001ab0664bd1de3)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortGeneratedTopCell{}, R} (
+            X0:SortGeneratedTopCell{},
+            Lbl'-LT-'generatedTop'-GT-'{}(Var'Unds'DotVar0:SortKCell{},VarCell:SortGeneratedCounterCell{})
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedCounterCell{},R} (
+      LblgetGeneratedCounterCell{}(X0:SortGeneratedTopCell{}),
+     \and{SortGeneratedCounterCell{}} (
+       VarCell:SortGeneratedCounterCell{},
+        \top{SortGeneratedCounterCell{}}())))
+  [UNIQUE'Unds'ID{}("9ef5eb9b9e6bbd7436911fad20615821f61e06e742dd27773001ab0664bd1de3")]
+
+// rule initGeneratedCounterCell(.KList)=>`<generatedCounter>`(#token("0","Int")) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5de11f6b50c4684c0e05b773f809d756f4ce9c03a4f24e23a9cddaf3fa31f553), initializer]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+
+          \top{R} ()
+        ),
+    \equals{SortGeneratedCounterCell{},R} (
+      LblinitGeneratedCounterCell{}(),
+     \and{SortGeneratedCounterCell{}} (
+       Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")),
+        \top{SortGeneratedCounterCell{}}())))
+  [UNIQUE'Unds'ID{}("5de11f6b50c4684c0e05b773f809d756f4ce9c03a4f24e23a9cddaf3fa31f553"), initializer{}()]
+
+// rule initGeneratedTopCell(Init)=>`<generatedTop>`(initKCell(Init),initGeneratedCounterCell(.KList)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4cbc9d1da6e6bfe3605113d64379a38394b46b474e41d7bf884f8912546543b1), initializer]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortMap{}, R} (
+            X0:SortMap{},
+            VarInit:SortMap{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedTopCell{},R} (
+      LblinitGeneratedTopCell{}(X0:SortMap{}),
+     \and{SortGeneratedTopCell{}} (
+       Lbl'-LT-'generatedTop'-GT-'{}(LblinitKCell{}(VarInit:SortMap{}),LblinitGeneratedCounterCell{}()),
+        \top{SortGeneratedTopCell{}}())))
+  [UNIQUE'Unds'ID{}("4cbc9d1da6e6bfe3605113d64379a38394b46b474e41d7bf884f8912546543b1"), initializer{}()]
+
+// rule initKCell(Init)=>`<k>`(`project:KItem`(`Map:lookup`(Init,inj{KConfigVar,KItem}(#token("$PGM","KConfigVar"))))) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(888ac40929773fd17d5b9fd1e9d0be94791665a663f07907d894c31dccc871a5), initializer]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortMap{}, R} (
+            X0:SortMap{},
+            VarInit:SortMap{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortKCell{},R} (
+      LblinitKCell{}(X0:SortMap{}),
+     \and{SortKCell{}} (
+       Lbl'-LT-'k'-GT-'{}(kseq{}(Lblproject'Coln'KItem{}(kseq{}(LblMap'Coln'lookup{}(VarInit:SortMap{},inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM"))),dotk{}())),dotk{}())),
+        \top{SortKCell{}}())))
+  [UNIQUE'Unds'ID{}("888ac40929773fd17d5b9fd1e9d0be94791665a663f07907d894c31dccc871a5"), initializer{}()]
+
+// rule isBool(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7f8273ebd616814dbf1acdd96b9534fbaa5b0491bfd05a61916e5015ad4a37ab), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortBool{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortBool{}, SortKItem{}}(Var'Unds'Gen1:SortBool{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisBool{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("7f8273ebd616814dbf1acdd96b9534fbaa5b0491bfd05a61916e5015ad4a37ab"), owise{}()]
+
+// rule isBool(inj{Bool,KItem}(Bool))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(dadad716b2f6a82fa4b2cc8f903a1b8f1f6e8cfa63f18b72a7cb35110bdcff77)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortBool{}, SortKItem{}}(VarBool:SortBool{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisBool{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("dadad716b2f6a82fa4b2cc8f903a1b8f1f6e8cfa63f18b72a7cb35110bdcff77")]
+
+// rule isGeneratedCounterCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7d501e1637f26769ad3b9439efef0285daa79523b0d071b3a792972ce92e4fe2), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortGeneratedCounterCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortGeneratedCounterCell{}, SortKItem{}}(Var'Unds'Gen1:SortGeneratedCounterCell{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisGeneratedCounterCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("7d501e1637f26769ad3b9439efef0285daa79523b0d071b3a792972ce92e4fe2"), owise{}()]
+
+// rule isGeneratedCounterCell(inj{GeneratedCounterCell,KItem}(GeneratedCounterCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f7b6a3dbee5a80d5eeba727f40009876995660d4052a45fc50c55f88c5fc1a7c)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedCounterCell{}, SortKItem{}}(VarGeneratedCounterCell:SortGeneratedCounterCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisGeneratedCounterCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("f7b6a3dbee5a80d5eeba727f40009876995660d4052a45fc50c55f88c5fc1a7c")]
+
+// rule isGeneratedCounterCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(55e7759c7640aa41fef8271d53c6dd8668aa497704539a65577604ada709c5df), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortGeneratedCounterCellOpt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortGeneratedCounterCellOpt{}, SortKItem{}}(Var'Unds'Gen0:SortGeneratedCounterCellOpt{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisGeneratedCounterCellOpt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("55e7759c7640aa41fef8271d53c6dd8668aa497704539a65577604ada709c5df"), owise{}()]
+
+// rule isGeneratedCounterCellOpt(inj{GeneratedCounterCellOpt,KItem}(GeneratedCounterCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(a4ff3e170677e099d4b28085658942cb10fcf871aa99abcdf73927596c180f12)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedCounterCellOpt{}, SortKItem{}}(VarGeneratedCounterCellOpt:SortGeneratedCounterCellOpt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisGeneratedCounterCellOpt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("a4ff3e170677e099d4b28085658942cb10fcf871aa99abcdf73927596c180f12")]
+
+// rule isGeneratedTopCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(ec16314688c4b2d204af490e243a3e83a2e82fbc74988c3574b997cc9ca56816), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortGeneratedTopCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortGeneratedTopCell{}, SortKItem{}}(Var'Unds'Gen1:SortGeneratedTopCell{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisGeneratedTopCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("ec16314688c4b2d204af490e243a3e83a2e82fbc74988c3574b997cc9ca56816"), owise{}()]
+
+// rule isGeneratedTopCell(inj{GeneratedTopCell,KItem}(GeneratedTopCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(3bcf423225700e329d0533cfd806eb9bab91f9d8de0979c8d8e381fe5d076bb2)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedTopCell{}, SortKItem{}}(VarGeneratedTopCell:SortGeneratedTopCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisGeneratedTopCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("3bcf423225700e329d0533cfd806eb9bab91f9d8de0979c8d8e381fe5d076bb2")]
+
+// rule isGeneratedTopCellFragment(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(1f022b25cc5a2adbe99fbae6b50007c803258a5749eb01e05c86096f7b35c0df), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortGeneratedTopCellFragment{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortGeneratedTopCellFragment{}, SortKItem{}}(Var'Unds'Gen0:SortGeneratedTopCellFragment{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisGeneratedTopCellFragment{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("1f022b25cc5a2adbe99fbae6b50007c803258a5749eb01e05c86096f7b35c0df"), owise{}()]
+
+// rule isGeneratedTopCellFragment(inj{GeneratedTopCellFragment,KItem}(GeneratedTopCellFragment))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(559f2cdc0ab425bb065cc3174f4a1af4d9ca834f762a814cf3dfbf9a9d7f8271)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedTopCellFragment{}, SortKItem{}}(VarGeneratedTopCellFragment:SortGeneratedTopCellFragment{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisGeneratedTopCellFragment{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("559f2cdc0ab425bb065cc3174f4a1af4d9ca834f762a814cf3dfbf9a9d7f8271")]
+
+// rule isInt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5c9850befff40cc79151dbc5a8999b5ffaad767f244ed97f9f29b56b7170bf24), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortInt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortInt{}, SortKItem{}}(Var'Unds'Gen1:SortInt{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisInt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("5c9850befff40cc79151dbc5a8999b5ffaad767f244ed97f9f29b56b7170bf24"), owise{}()]
+
+// rule isInt(inj{Int,KItem}(Int))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(92664aa821c8898ff16b4e72ad0bdf363f755c7660d28dcb69c129a2c94bc6b5)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortInt{}, SortKItem{}}(VarInt:SortInt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisInt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("92664aa821c8898ff16b4e72ad0bdf363f755c7660d28dcb69c129a2c94bc6b5")]
+
+// rule isK(K)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(16ff77cff0ef50026a8b3f4614b87bda465701918596b7ad2280baffff56f847)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisK{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("16ff77cff0ef50026a8b3f4614b87bda465701918596b7ad2280baffff56f847")]
+
+// rule isKCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(1668e9146ab7dd7867682198dd9dddc0c7c88d8f9fad9ed2366229fc4db18733), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortKCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortKCell{}, SortKItem{}}(Var'Unds'Gen0:SortKCell{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisKCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("1668e9146ab7dd7867682198dd9dddc0c7c88d8f9fad9ed2366229fc4db18733"), owise{}()]
+
+// rule isKCell(inj{KCell,KItem}(KCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2695222b1238f711f8a356c0a1bc0ac418d7bd78fd3282e7c60882e2631a46df)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortKCell{}, SortKItem{}}(VarKCell:SortKCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisKCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("2695222b1238f711f8a356c0a1bc0ac418d7bd78fd3282e7c60882e2631a46df")]
+
+// rule isKCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(fa44a9c94132ade195fc2cb566fa82471e4592c977a49183ac2142c5062701ca), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortKCellOpt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortKCellOpt{}, SortKItem{}}(Var'Unds'Gen1:SortKCellOpt{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisKCellOpt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("fa44a9c94132ade195fc2cb566fa82471e4592c977a49183ac2142c5062701ca"), owise{}()]
+
+// rule isKCellOpt(inj{KCellOpt,KItem}(KCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(1516473b1e153a368c273997543a4378ad451e5e828db8e289f4447f7e5228a5)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortKCellOpt{}, SortKItem{}}(VarKCellOpt:SortKCellOpt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisKCellOpt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("1516473b1e153a368c273997543a4378ad451e5e828db8e289f4447f7e5228a5")]
+
+// rule isKConfigVar(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f1c02853e001635e66a06d14d1cd322a996f4acbe38a7f9c88df6c97ea6a4677), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortKConfigVar{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortKConfigVar{}, SortKItem{}}(Var'Unds'Gen0:SortKConfigVar{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisKConfigVar{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("f1c02853e001635e66a06d14d1cd322a996f4acbe38a7f9c88df6c97ea6a4677"), owise{}()]
+
+// rule isKConfigVar(inj{KConfigVar,KItem}(KConfigVar))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(0ef0a00bb321f2c2a62a3239327de70ecb8e907a950cd20034c46b84e040ebcd)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortKConfigVar{}, SortKItem{}}(VarKConfigVar:SortKConfigVar{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisKConfigVar{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("0ef0a00bb321f2c2a62a3239327de70ecb8e907a950cd20034c46b84e040ebcd")]
+
+// rule isKItem(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f766beabd3e632a98e221201d003f26f45f1feef2aff6da0ab07edde06a5d99d), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortKItem{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(Var'Unds'Gen0:SortKItem{},dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisKItem{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("f766beabd3e632a98e221201d003f26f45f1feef2aff6da0ab07edde06a5d99d"), owise{}()]
+
+// rule isKItem(KItem)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(ed3c25a7dab5e5fbc101589e2fa74ac91aa107f051d22a01378222d08643373c)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(VarKItem:SortKItem{},dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisKItem{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("ed3c25a7dab5e5fbc101589e2fa74ac91aa107f051d22a01378222d08643373c")]
+
+// rule isList(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(0b6d1ffc254fbf57473abfe22e81bcfa646561c43d4e2cc175eab60cfb2b68aa), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortList{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortList{}, SortKItem{}}(Var'Unds'Gen1:SortList{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisList{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("0b6d1ffc254fbf57473abfe22e81bcfa646561c43d4e2cc175eab60cfb2b68aa"), owise{}()]
+
+// rule isList(inj{List,KItem}(List))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7d4dddf5bbdb61cfd11fb9be1071be7bd551cf186607cf6f493cfade3221c446)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortList{}, SortKItem{}}(VarList:SortList{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisList{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("7d4dddf5bbdb61cfd11fb9be1071be7bd551cf186607cf6f493cfade3221c446")]
+
+// rule isMap(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5da72349a323db3019243ab26f08b728d336c1a52aecaa0bcb7de4adae14bd71), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortMap{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortMap{}, SortKItem{}}(Var'Unds'Gen1:SortMap{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisMap{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("5da72349a323db3019243ab26f08b728d336c1a52aecaa0bcb7de4adae14bd71"), owise{}()]
+
+// rule isMap(inj{Map,KItem}(Map))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4879c0fcf6b7d7f3d6b751e4f460f8dced005a44ae5ff600cffcea784cf58795)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortMap{}, SortKItem{}}(VarMap:SortMap{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisMap{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("4879c0fcf6b7d7f3d6b751e4f460f8dced005a44ae5ff600cffcea784cf58795")]
+
+// rule isSet(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4bb33358689dc4ec69171f146dc69c169560a878b09ca872d2c4da9e2dbd0d5e), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortSet{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortSet{}, SortKItem{}}(Var'Unds'Gen1:SortSet{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisSet{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("4bb33358689dc4ec69171f146dc69c169560a878b09ca872d2c4da9e2dbd0d5e"), owise{}()]
+
+// rule isSet(inj{Set,KItem}(Set))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f205bc460bdb728b4c3458643699be30d519db4d8b13e80e2c27082b9e846e80)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortSet{}, SortKItem{}}(VarSet:SortSet{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisSet{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("f205bc460bdb728b4c3458643699be30d519db4d8b13e80e2c27082b9e846e80")]
+
+// rule `minInt(_,_)_INT-COMMON_Int_Int_Int`(I1,I2)=>I1 requires `_<=Int_`(I1,I2) ensures #token("true","Bool") [UNIQUE_ID(fb09b6acc4366cb77203e07c4efe8a9cf304e1bac9fb0664deea05d3eb9a80c6), org.kframework.attributes.Location(Location(1428,8,1428,57)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds-LT-Eqls'Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{}),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI1:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI2:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortInt{},R} (
+      LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortInt{}} (
+       VarI1:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("fb09b6acc4366cb77203e07c4efe8a9cf304e1bac9fb0664deea05d3eb9a80c6"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1428,8,1428,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]")]
+
+// rule `minInt(_,_)_INT-COMMON_Int_Int_Int`(I1,I2)=>I2 requires `_>=Int_`(I1,I2) ensures #token("true","Bool") [UNIQUE_ID(e1effeabf96bb3a3beffd5b679ad5df95c4f8bbf42872b0793331e52a8470fb3), org.kframework.attributes.Location(Location(1429,8,1429,57)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds-GT-Eqls'Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{}),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI1:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI2:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortInt{},R} (
+      LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortInt{}} (
+       VarI2:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("e1effeabf96bb3a3beffd5b679ad5df95c4f8bbf42872b0793331e52a8470fb3"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1429,8,1429,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]")]
+
+// rule `notBool_`(#token("false","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(17ebc68421572b8ebe609c068fb49cbb6cbbe3246e2142257ad8befdda38f415), org.kframework.attributes.Location(Location(1119,8,1119,29)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblnotBool'Unds'{}(X0:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("17ebc68421572b8ebe609c068fb49cbb6cbbe3246e2142257ad8befdda38f415"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1119,8,1119,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `notBool_`(#token("true","Bool"))=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(53fc758ece1ff16581673016dfacc556cc30fcf6b3c35b586f001d76a1f9336c), org.kframework.attributes.Location(Location(1118,8,1118,29)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblnotBool'Unds'{}(X0:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("53fc758ece1ff16581673016dfacc556cc30fcf6b3c35b586f001d76a1f9336c"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1118,8,1118,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `project:Bool`(inj{Bool,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5872f0d5b8131216db7bc41e2c3a423e55f4b8581589fcbd1bf93b2ca6862d54), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortBool{}, SortKItem{}}(VarK:SortBool{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      Lblproject'Coln'Bool{}(X0:SortK{}),
+     \and{SortBool{}} (
+       VarK:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("5872f0d5b8131216db7bc41e2c3a423e55f4b8581589fcbd1bf93b2ca6862d54"), projection{}()]
+
+// rule `project:GeneratedCounterCell`(inj{GeneratedCounterCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(63453db9d9aa121b63bb877e2fa4998d399ef82d2a1e4b90f87a32ba55401217), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedCounterCell{}, SortKItem{}}(VarK:SortGeneratedCounterCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedCounterCell{},R} (
+      Lblproject'Coln'GeneratedCounterCell{}(X0:SortK{}),
+     \and{SortGeneratedCounterCell{}} (
+       VarK:SortGeneratedCounterCell{},
+        \top{SortGeneratedCounterCell{}}())))
+  [UNIQUE'Unds'ID{}("63453db9d9aa121b63bb877e2fa4998d399ef82d2a1e4b90f87a32ba55401217"), projection{}()]
+
+// rule `project:GeneratedCounterCellOpt`(inj{GeneratedCounterCellOpt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9325a900267ae528f7cd09f3b44b825dd9ff344c38d38383c08fa697cc67efca), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedCounterCellOpt{}, SortKItem{}}(VarK:SortGeneratedCounterCellOpt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedCounterCellOpt{},R} (
+      Lblproject'Coln'GeneratedCounterCellOpt{}(X0:SortK{}),
+     \and{SortGeneratedCounterCellOpt{}} (
+       VarK:SortGeneratedCounterCellOpt{},
+        \top{SortGeneratedCounterCellOpt{}}())))
+  [UNIQUE'Unds'ID{}("9325a900267ae528f7cd09f3b44b825dd9ff344c38d38383c08fa697cc67efca"), projection{}()]
+
+// rule `project:GeneratedTopCell`(inj{GeneratedTopCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(b0fabd8c7c81fe08ebd569aff59747d357e441ae1fcd05d9d594d57e38e3d55e), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedTopCell{}, SortKItem{}}(VarK:SortGeneratedTopCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedTopCell{},R} (
+      Lblproject'Coln'GeneratedTopCell{}(X0:SortK{}),
+     \and{SortGeneratedTopCell{}} (
+       VarK:SortGeneratedTopCell{},
+        \top{SortGeneratedTopCell{}}())))
+  [UNIQUE'Unds'ID{}("b0fabd8c7c81fe08ebd569aff59747d357e441ae1fcd05d9d594d57e38e3d55e"), projection{}()]
+
+// rule `project:GeneratedTopCellFragment`(inj{GeneratedTopCellFragment,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2084fac322aa142a07f881814b8a286bf62d5c6d05777b7aa715ccc534cf9a42), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedTopCellFragment{}, SortKItem{}}(VarK:SortGeneratedTopCellFragment{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedTopCellFragment{},R} (
+      Lblproject'Coln'GeneratedTopCellFragment{}(X0:SortK{}),
+     \and{SortGeneratedTopCellFragment{}} (
+       VarK:SortGeneratedTopCellFragment{},
+        \top{SortGeneratedTopCellFragment{}}())))
+  [UNIQUE'Unds'ID{}("2084fac322aa142a07f881814b8a286bf62d5c6d05777b7aa715ccc534cf9a42"), projection{}()]
+
+// rule `project:Int`(inj{Int,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f316b871091516c401f1d2382cc5f66322602b782c7b01e1aeb6c2ddab50e24b), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortInt{}, SortKItem{}}(VarK:SortInt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortInt{},R} (
+      Lblproject'Coln'Int{}(X0:SortK{}),
+     \and{SortInt{}} (
+       VarK:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("f316b871091516c401f1d2382cc5f66322602b782c7b01e1aeb6c2ddab50e24b"), projection{}()]
+
+// rule `project:K`(K)=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(25b529ddcefd25ef63f99a62040145ef27638e7679ea9202218fe14be98dff3a), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortK{},R} (
+      Lblproject'Coln'K{}(X0:SortK{}),
+     \and{SortK{}} (
+       VarK:SortK{},
+        \top{SortK{}}())))
+  [UNIQUE'Unds'ID{}("25b529ddcefd25ef63f99a62040145ef27638e7679ea9202218fe14be98dff3a"), projection{}()]
+
+// rule `project:KCell`(inj{KCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(894c13c4c410f11e35bc3781505aeddde4ff400ddda1daf8b35259dbf0de9a24), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortKCell{}, SortKItem{}}(VarK:SortKCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortKCell{},R} (
+      Lblproject'Coln'KCell{}(X0:SortK{}),
+     \and{SortKCell{}} (
+       VarK:SortKCell{},
+        \top{SortKCell{}}())))
+  [UNIQUE'Unds'ID{}("894c13c4c410f11e35bc3781505aeddde4ff400ddda1daf8b35259dbf0de9a24"), projection{}()]
+
+// rule `project:KCellOpt`(inj{KCellOpt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f684dd78d97feadf0cbcb3cbb8892e0842f137c7b29a904cb2f3fc9755b29b30), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortKCellOpt{}, SortKItem{}}(VarK:SortKCellOpt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortKCellOpt{},R} (
+      Lblproject'Coln'KCellOpt{}(X0:SortK{}),
+     \and{SortKCellOpt{}} (
+       VarK:SortKCellOpt{},
+        \top{SortKCellOpt{}}())))
+  [UNIQUE'Unds'ID{}("f684dd78d97feadf0cbcb3cbb8892e0842f137c7b29a904cb2f3fc9755b29b30"), projection{}()]
+
+// rule `project:KItem`(K)=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(1242e49c17638c9a66a35e3bb8c237288f7e9aa9a6499101e8cdc55be320cd29), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(VarK:SortKItem{},dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortKItem{},R} (
+      Lblproject'Coln'KItem{}(X0:SortK{}),
+     \and{SortKItem{}} (
+       VarK:SortKItem{},
+        \top{SortKItem{}}())))
+  [UNIQUE'Unds'ID{}("1242e49c17638c9a66a35e3bb8c237288f7e9aa9a6499101e8cdc55be320cd29"), projection{}()]
+
+// rule `project:List`(inj{List,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2b75eac5a59779d336e6cf9632bf9ba7d67286f322e753108b34e62f2443efe5), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortList{}, SortKItem{}}(VarK:SortList{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortList{},R} (
+      Lblproject'Coln'List{}(X0:SortK{}),
+     \and{SortList{}} (
+       VarK:SortList{},
+        \top{SortList{}}())))
+  [UNIQUE'Unds'ID{}("2b75eac5a59779d336e6cf9632bf9ba7d67286f322e753108b34e62f2443efe5"), projection{}()]
+
+// rule `project:Map`(inj{Map,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(031237d4aae58d86914d6370d37ccd15f4738378ed780333c59cc81b4f7bc598), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortMap{}, SortKItem{}}(VarK:SortMap{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortMap{},R} (
+      Lblproject'Coln'Map{}(X0:SortK{}),
+     \and{SortMap{}} (
+       VarK:SortMap{},
+        \top{SortMap{}}())))
+  [UNIQUE'Unds'ID{}("031237d4aae58d86914d6370d37ccd15f4738378ed780333c59cc81b4f7bc598"), projection{}()]
+
+// rule `project:Set`(inj{Set,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(0e7f5070c993161786e314f7199d985afebac9e07b5c784f6f623780c60ce9d0), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortSet{}, SortKItem{}}(VarK:SortSet{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortSet{},R} (
+      Lblproject'Coln'Set{}(X0:SortK{}),
+     \and{SortSet{}} (
+       VarK:SortSet{},
+        \top{SortSet{}}())))
+  [UNIQUE'Unds'ID{}("0e7f5070c993161786e314f7199d985afebac9e07b5c784f6f623780c60ce9d0"), projection{}()]
+
+// rule `signExtendBitRangeInt(_,_,_)_INT-COMMON_Int_Int_Int_Int`(I,IDX,LEN)=>`_-Int_`(`_modInt_`(`_+Int_`(`bitRangeInt(_,_,_)_INT-COMMON_Int_Int_Int_Int`(I,IDX,LEN),`_<<Int_`(#token("1","Int"),`_-Int_`(LEN,#token("1","Int")))),`_<<Int_`(#token("1","Int"),LEN)),`_<<Int_`(#token("1","Int"),`_-Int_`(LEN,#token("1","Int")))) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(3b67f4bf2235fc46fc94b1d10e936100ea3fc4f2dbaa4e4a77593e8385f5004f), org.kframework.attributes.Location(Location(1418,8,1418,164)), org.kframework.attributes.Source(Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarIDX:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X2:SortInt{},
+            VarLEN:SortInt{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortInt{},R} (
+      LblsignExtendBitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{},X2:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'Unds'-Int'Unds'{}(Lbl'Unds'modInt'Unds'{}(Lbl'UndsPlus'Int'Unds'{}(LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(VarI:SortInt{},VarIDX:SortInt{},VarLEN:SortInt{}),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),Lbl'Unds'-Int'Unds'{}(VarLEN:SortInt{},\dv{SortInt{}}("1")))),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),VarLEN:SortInt{})),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),Lbl'Unds'-Int'Unds'{}(VarLEN:SortInt{},\dv{SortInt{}}("1")))),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("3b67f4bf2235fc46fc94b1d10e936100ea3fc4f2dbaa4e4a77593e8385f5004f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1418,8,1418,164)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/n91a63s0zf1r2y83j431rjwirzyis4gp-k-5.6.130-c3e1fb7ba901cc28ec4bb52a676ea329ba19c955-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule #Ceil{Map,#SortParam}(`_Map_`(`_|->_`(@K0,@K1),@Rest))=>#And{#SortParam}(#Equals{Bool,#SortParam}(`_in_keys(_)_MAP_Bool_KItem_Map`(@K0,@Rest),#token("false","Bool")),#And{#SortParam}(#Top{#SortParam}(.KList),#Ceil{KItem,#SortParam}(@K1))) requires #token("true","Bool") ensures #token("true","Bool") [simplification, sortParams({Q0})]
+  axiom{R,Q0} \implies{R} (
+    \top{R}(),
+    \equals{Q0,R} (
+      \ceil{SortMap{}, Q0}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(@VarK0:SortKItem{},@VarK1:SortKItem{}),@VarRest:SortMap{})),
+     \and{Q0} (
+       \and{Q0}(\equals{SortBool{}, Q0}(Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'Unds'Bool'Unds'KItem'Unds'Map{}(@VarK0:SortKItem{},@VarRest:SortMap{}),\dv{SortBool{}}("false")),\and{Q0}(\top{Q0}(),\ceil{SortKItem{}, Q0}(@VarK1:SortKItem{}))),
+        \top{Q0}())))
+  [simplification{}(""), sortParams{}("{Q0}")]
+
+endmodule [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1,1,5,10)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(int-and-bool.k)")]

--- a/test/rpc-integration/runDirectoryTest.sh
+++ b/test/rpc-integration/runDirectoryTest.sh
@@ -70,7 +70,7 @@ echo "Server PID ${server_pid}"
 
 sleep 2
 
-for test in $( ls $dir/state-*.{execute,send,simplify} ); do
+for test in $( ls $dir/state-*.{execute,send,simplify,add-module,get-model} 2>/dev/null ); do
     tmp=${test#$dir/state-}
     testname=${tmp%.*}
     # determine send mode from suffix

--- a/test/rpc-integration/test-get-model/README.md
+++ b/test/rpc-integration/test-get-model/README.md
@@ -1,0 +1,19 @@
+# Testing `get-model`
+
+For the time being, this is testing the pass-through of `get-model` requests to the `kore-rpc`. At the time of writing, all tests are [replicated from `haskell-backend`](https://github.com/runtimeverification/haskell-backend/tree/master/test/rpc-server/get-model) test suite without modifications.
+
+* an input without a predicate:
+  - Input kore term: `\and(\not(X:SortBool), X:SortBool)` , interpreted as a _term_, not as a predicate. Therefore, the input does not have any predicate, and the server returns an indeterminate result.
+  - Result: `unknown`
+* a non-satisfiable predicate
+  - Input: `X >= 10 && X < 5`
+  - Result: `unsat`
+* a non-satisfiable predicate with variables
+  - Input kore term: `\equals(\not(X:SortBool), X:SortBool)`
+  - Result: `unsat`
+* satisfiable predicates
+  - Input: `X <= 10 && X < 5`
+  - Result: `sat`, substitution `X = 0`
+* a trivial satisfiable predicate without variables
+  - Input kore term: ` 0 <= 0`
+  - Result: `sat`, no substitution

--- a/test/rpc-integration/test-get-model/response-no-predicate.json
+++ b/test/rpc-integration/test-get-model/response-no-predicate.json
@@ -1,0 +1,7 @@
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+        "satisfiable": "Unknown"
+    }
+}

--- a/test/rpc-integration/test-get-model/response-not-satisfiable-vars.json
+++ b/test/rpc-integration/test-get-model/response-not-satisfiable-vars.json
@@ -1,0 +1,7 @@
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+        "satisfiable": "Unsat"
+    }
+}

--- a/test/rpc-integration/test-get-model/response-not-satisfiable.json
+++ b/test/rpc-integration/test-get-model/response-not-satisfiable.json
@@ -1,0 +1,7 @@
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+        "satisfiable": "Unsat"
+    }
+}

--- a/test/rpc-integration/test-get-model/response-satisfiable.json
+++ b/test/rpc-integration/test-get-model/response-satisfiable.json
@@ -1,0 +1,42 @@
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+        "substitution": {
+            "format": "KORE",
+            "version": 1,
+            "term": {
+                "tag": "Equals",
+                "argSort": {
+                    "tag": "SortApp",
+                    "name": "SortInt",
+                    "args": []
+                },
+                "sort": {
+                    "tag": "SortApp",
+                    "name": "SortBool",
+                    "args": []
+                },
+                "first": {
+                    "tag": "EVar",
+                    "name": "X",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    }
+                },
+                "second": {
+                    "tag": "DV",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    },
+                    "value": "0"
+                }
+            }
+        },
+        "satisfiable": "Sat"
+    }
+}

--- a/test/rpc-integration/test-get-model/response-trivial.json
+++ b/test/rpc-integration/test-get-model/response-trivial.json
@@ -1,0 +1,7 @@
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+        "satisfiable": "Sat"
+    }
+}

--- a/test/rpc-integration/test-get-model/state-no-predicate.get-model
+++ b/test/rpc-integration/test-get-model/state-no-predicate.get-model
@@ -1,0 +1,38 @@
+{
+  "format": "KORE",
+  "version": 1,
+  "term": {
+    "tag": "And",
+    "sort": {
+      "tag": "SortApp",
+      "name": "SortBool",
+      "args": []
+    },
+    "first": {
+      "tag": "Not",
+      "sort": {
+        "tag": "SortApp",
+        "name": "SortBool",
+        "args": []
+      },
+      "arg": {
+        "tag": "EVar",
+        "name": "X",
+        "sort": {
+          "tag": "SortApp",
+          "name": "SortBool",
+          "args": []
+        }
+      }
+    },
+    "second": {
+      "tag": "EVar",
+      "name": "X",
+      "sort": {
+        "tag": "SortApp",
+        "name": "SortBool",
+        "args": []
+      }
+    }
+  }
+}

--- a/test/rpc-integration/test-get-model/state-not-satisfiable-vars.get-model
+++ b/test/rpc-integration/test-get-model/state-not-satisfiable-vars.get-model
@@ -1,0 +1,43 @@
+{
+  "format": "KORE",
+  "version": 1,
+  "term": {
+    "tag": "Equals",
+    "sort": {
+      "tag": "SortApp",
+      "name": "SortBool",
+      "args": []
+    },
+    "argSort": {
+      "tag": "SortApp",
+      "name": "SortBool",
+      "args": []
+    },
+    "first": {
+      "tag": "Not",
+      "sort": {
+        "tag": "SortApp",
+        "name": "SortBool",
+        "args": []
+      },
+      "arg": {
+        "tag": "EVar",
+        "name": "X",
+        "sort": {
+          "tag": "SortApp",
+          "name": "SortBool",
+          "args": []
+        }
+      }
+    },
+    "second": {
+      "tag": "EVar",
+      "name": "X",
+      "sort": {
+        "tag": "SortApp",
+        "name": "SortBool",
+        "args": []
+      }
+    }
+  }
+}

--- a/test/rpc-integration/test-get-model/state-not-satisfiable.get-model
+++ b/test/rpc-integration/test-get-model/state-not-satisfiable.get-model
@@ -1,0 +1,106 @@
+{
+  "format": "KORE",
+  "version": 1,
+  "term": {
+    "tag": "And",
+    "sort": {
+      "tag": "SortApp",
+      "name": "SortBool",
+      "args": []
+    },
+    "first": {
+      "tag": "Equals",
+      "argSort": {
+        "tag": "SortApp",
+        "name": "SortBool",
+        "args": []
+      },
+      "sort": {
+        "tag": "SortApp",
+        "name": "SortBool",
+        "args": []
+      },
+      "first": {
+        "tag": "DV",
+        "sort": {
+          "tag": "SortApp",
+          "name": "SortBool",
+          "args": []
+        },
+        "value": "true"
+      },
+      "second": {
+        "tag": "App",
+        "name": "Lbl'Unds-GT-Eqls'Int'Unds'",
+        "sorts": [],
+        "args": [
+          {
+            "tag": "EVar",
+            "name": "X",
+            "sort": {
+              "tag": "SortApp",
+              "name": "SortInt",
+              "args": []
+            }
+          },
+          {
+            "tag": "DV",
+            "sort": {
+              "tag": "SortApp",
+              "name": "SortInt",
+              "args": []
+            },
+            "value": "10"
+          }
+        ]
+      }
+    },
+    "second": {
+      "tag": "Equals",
+      "argSort": {
+        "tag": "SortApp",
+        "name": "SortBool",
+        "args": []
+      },
+      "sort": {
+        "tag": "SortApp",
+        "name": "SortBool",
+        "args": []
+      },
+      "first": {
+        "tag": "DV",
+        "sort": {
+          "tag": "SortApp",
+          "name": "SortBool",
+          "args": []
+        },
+        "value": "true"
+      },
+      "second": {
+        "tag": "App",
+        "name": "Lbl'Unds-LT-'Int'Unds'",
+        "sorts": [],
+        "args": [
+          {
+            "tag": "EVar",
+            "name": "X",
+            "sort": {
+              "tag": "SortApp",
+              "name": "SortInt",
+              "args": []
+            }
+          },
+          {
+            "tag": "DV",
+            "sort": {
+              "tag": "SortApp",
+              "name": "SortInt",
+              "args": []
+            },
+            "value": "5"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/rpc-integration/test-get-model/state-satisfiable.get-model
+++ b/test/rpc-integration/test-get-model/state-satisfiable.get-model
@@ -1,0 +1,106 @@
+{
+  "format": "KORE",
+  "version": 1,
+  "term": {
+    "tag": "And",
+    "sort": {
+      "tag": "SortApp",
+      "name": "SortBool",
+      "args": []
+    },
+    "first": {
+      "tag": "Equals",
+      "argSort": {
+        "tag": "SortApp",
+        "name": "SortBool",
+        "args": []
+      },
+      "sort": {
+        "tag": "SortApp",
+        "name": "SortBool",
+        "args": []
+      },
+      "first": {
+        "tag": "DV",
+        "sort": {
+          "tag": "SortApp",
+          "name": "SortBool",
+          "args": []
+        },
+        "value": "true"
+      },
+      "second": {
+        "tag": "App",
+        "name": "Lbl'Unds-LT-Eqls'Int'Unds'",
+        "sorts": [],
+        "args": [
+          {
+            "tag": "EVar",
+            "name": "X",
+            "sort": {
+              "tag": "SortApp",
+              "name": "SortInt",
+              "args": []
+            }
+          },
+          {
+            "tag": "DV",
+            "sort": {
+              "tag": "SortApp",
+              "name": "SortInt",
+              "args": []
+            },
+            "value": "10"
+          }
+        ]
+      }
+    },
+    "second": {
+      "tag": "Equals",
+      "argSort": {
+        "tag": "SortApp",
+        "name": "SortBool",
+        "args": []
+      },
+      "sort": {
+        "tag": "SortApp",
+        "name": "SortBool",
+        "args": []
+      },
+      "first": {
+        "tag": "DV",
+        "sort": {
+          "tag": "SortApp",
+          "name": "SortBool",
+          "args": []
+        },
+        "value": "true"
+      },
+      "second": {
+        "tag": "App",
+        "name": "Lbl'Unds-LT-'Int'Unds'",
+        "sorts": [],
+        "args": [
+          {
+            "tag": "EVar",
+            "name": "X",
+            "sort": {
+              "tag": "SortApp",
+              "name": "SortInt",
+              "args": []
+            }
+          },
+          {
+            "tag": "DV",
+            "sort": {
+              "tag": "SortApp",
+              "name": "SortInt",
+              "args": []
+            },
+            "value": "5"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/rpc-integration/test-get-model/state-trivial.get-model
+++ b/test/rpc-integration/test-get-model/state-trivial.get-model
@@ -1,0 +1,51 @@
+{
+  "format": "KORE",
+  "version": 1,
+  "term": {
+    "tag": "Equals",
+    "argSort": {
+      "tag": "SortApp",
+      "name": "SortBool",
+      "args": []
+    },
+    "sort": {
+      "tag": "SortApp",
+      "name": "SortBool",
+      "args": []
+    },
+    "first": {
+      "tag": "DV",
+      "sort": {
+        "tag": "SortApp",
+        "name": "SortBool",
+        "args": []
+      },
+      "value": "true"
+    },
+    "second": {
+      "tag": "App",
+      "name": "Lbl'Unds-LT-Eqls'Int'Unds'",
+      "sorts": [],
+      "args": [
+        {
+          "tag": "DV",
+          "sort": {
+            "tag": "SortApp",
+            "name": "SortInt",
+            "args": []
+          },
+          "value": "0"
+        },
+        {
+          "tag": "DV",
+          "sort": {
+            "tag": "SortApp",
+            "name": "SortInt",
+            "args": []
+          },
+          "value": "0"
+        }
+      ]
+    }
+  }
+}

--- a/test/rpc-integration/test-module-addition/state-03-add-new-module.add-module
+++ b/test/rpc-integration/test-module-addition/state-03-add-new-module.add-module
@@ -1,0 +1,1 @@
+../resources/module-addition/module-addition-new.kore

--- a/test/rpc-integration/test-module-addition/state-03-add-new-module.send
+++ b/test/rpc-integration/test-module-addition/state-03-add-new-module.send
@@ -1,9 +1,0 @@
-{
-    "jsonrpc": "2.0",
-    "id": 1,
-    "method": "add-module",
-    "params": {
-        "name": "NEW",
-        "module": "module NEW\n  import TEST []\n\n// hand-written rules, purposely not providing some of the usual attributes and using the simplest possible form\n  axiom{} \\rewrites{SortGeneratedTopCell{}} (\n    \\and{SortGeneratedTopCell{}} (\n      \\top{SortGeneratedTopCell{}}(),\n      Lbl'-LT-'generatedTop'-GT-'{}(\n        Lbl'-LT-'k'-GT-'{}(\n          kseq{}(inj{SortState{}, SortKItem{}}(\\dv{SortState{}}(\"d\")),Var'Unds'DotVar1:SortK{})\n        ),\n        Var'Unds'DotVar0:SortGeneratedCounterCell{}\n      )\n    ),\n    Lbl'-LT-'generatedTop'-GT-'{}(\n      Lbl'-LT-'k'-GT-'{}(\n        kseq{}(inj{SortState{}, SortKItem{}}(\\dv{SortState{}}(\"e\")),Var'Unds'DotVar1:SortK{})\n      ),\n      Var'Unds'DotVar0:SortGeneratedCounterCell{}\n    )\n  )\n  [label{}(\"NEW.DE\")] // optional label\n\n  axiom{} \\rewrites{SortGeneratedTopCell{}} (\n    \\and{SortGeneratedTopCell{}} (\n      \\top{SortGeneratedTopCell{}}(),\n      Lbl'-LT-'generatedTop'-GT-'{}(\n        Lbl'-LT-'k'-GT-'{}(\n          kseq{}(inj{SortState{}, SortKItem{}}(\\dv{SortState{}}(\"e\")),Var'Unds'DotVar1:SortK{})\n        ),\n        Var'Unds'DotVar0:SortGeneratedCounterCell{}\n      )\n    ),\n    Lbl'-LT-'generatedTop'-GT-'{}(\n      Lbl'-LT-'k'-GT-'{}(\n        kseq{}(inj{SortState{}, SortKItem{}}(\\dv{SortState{}}(\"f\")),Var'Unds'DotVar1:SortK{})\n      ),\n      Var'Unds'DotVar0:SortGeneratedCounterCell{}\n    )\n  )\n  [] // no label, no unique ID (rewrite tracing is unable to refer to this rule)\n\nendmodule []\n"
-    }
-}

--- a/tools/booster/Proxy.hs
+++ b/tools/booster/Proxy.hs
@@ -114,6 +114,8 @@ respondEither mbStatsVar booster kore req = case req of
                 (koreRes, koreTime) <- withTime $ kore req
                 logStats AddModuleM (boosterTime + koreTime, koreTime)
                 pure koreRes
+    GetModel _ ->
+        loggedKore GetModelM req
     Cancel ->
         pure $ Left $ ErrorObj "Cancel not supported" (-32601) Null
   where

--- a/tools/rpc-client/RpcClient.hs
+++ b/tools/rpc-client/RpcClient.hs
@@ -91,6 +91,8 @@ data Options = Options
 data Mode
     = Exec FilePath
     | Simpl FilePath
+    | AddModule FilePath
+    | GetModel FilePath
     | Check FilePath FilePath
     | SendRaw FilePath
     deriving stock (Show)
@@ -99,6 +101,8 @@ getModeFile :: Mode -> FilePath
 getModeFile = \case
     Exec f -> f
     Simpl f -> f
+    AddModule f -> f
+    GetModel f -> f
     Check f1 _ -> f1
     SendRaw f -> f
 
@@ -191,6 +195,8 @@ parseMode =
     parse Exec "execute" "execute (rewrite) the state in the file"
         <|> parse SendRaw "send" "send the raw file contents directly"
         <|> parse Simpl "simplify" "simplify the state or condition in the file"
+        <|> parse AddModule "add-module" "add the module in the given kore file"
+        <|> parse GetModel "get-model" "check satisfiability/provide model for the state in the file"
   where
     --    <|> parse Check "implies" "check implication between antecedent and consequent in the file"
 
@@ -210,6 +216,22 @@ prepareRequestData (Exec file) mbOptFile opts =
     prepareOneTermRequest "execute" file mbOptFile opts
 prepareRequestData (Simpl file) mbOptFile opts =
     prepareOneTermRequest "simplify" file mbOptFile opts
+prepareRequestData (AddModule file) mbOptFile opts = do
+    unless (isNothing mbOptFile) $
+        hPutStrLn stderr "[Warning] Add-module mode, ignoring given option file"
+    unless (null opts) $
+        hPutStrLn stderr "[Warning] Raw mode, ignoring given request options"
+    moduleText <- readFile file
+    pure . Json.encode $
+        object
+            [ "jsonrpc" ~> "2.0"
+            , "id" ~> "1"
+            , "method" ~> "add-module"
+            ]
+            +: "params"
+            ~> Json.Object (object ["module" ~> moduleText])
+prepareRequestData (GetModel file) mbOptFile opts =
+    prepareOneTermRequest "get-model" file mbOptFile opts
 prepareRequestData (Check _file1 _file2) _mbOptFile _opts = do
     error "not implemented yet"
 


### PR DESCRIPTION
Fixes #199 

Also added `get-model` and `add-module` support to `rpc-client` and replicated the `get-model` integration tests