### PR TITLE
Supply version info the rev hash when building via Nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,8 @@
     };
   };
 
-  outputs = { self, nixpkgs, haskell-nix, k-framework, haskell-backend, ... }@inputs:
+  outputs =
+    { self, nixpkgs, haskell-nix, k-framework, haskell-backend, ... }@inputs:
     let
       inherit (nixpkgs) lib;
       perSystem = lib.genAttrs nixpkgs.lib.systems.flakeExposed;
@@ -21,24 +22,14 @@
         import nixpkgs {
           inherit (haskell-nix) config;
           inherit system;
-          overlays = [ haskell-nix.overlays.combined haskell-backend.overlays.z3 ];
+          overlays =
+            [ haskell-nix.overlays.combined haskell-backend.overlays.z3 ];
         };
       allNixpkgsFor = perSystem nixpkgsForSystem;
       nixpkgsFor = system: allNixpkgsFor.${system};
       index-state = "2023-04-24T00:00:00Z";
 
       boosterBackendFor = { compiler, pkgs, profiling ? false, k }:
-        let
-          add-z3 = exe: {
-            build-tools = with pkgs; lib.mkForce [ makeWrapper ];
-            postInstall = ''
-              wrapProgram $out/bin/${exe} --prefix PATH : ${
-                with pkgs;
-                lib.makeBinPath [ z3 ]
-              }
-            '';
-          };
-        in
         pkgs.haskell-nix.cabalProject {
           name = "hs-backend-booster";
           supportHpack = true;
@@ -95,7 +86,9 @@
             packages.hs-backend-booster.components.tests.llvm-integration = {
               build-tools = with pkgs; lib.mkForce [ makeWrapper ];
               postInstall = ''
-                wrapProgram $out/bin/llvm-integration --prefix PATH : ${lib.makeBinPath [ k ]}
+                wrapProgram $out/bin/llvm-integration --prefix PATH : ${
+                  lib.makeBinPath [ k ]
+                }
               '';
             };
 
@@ -152,8 +145,7 @@
           pkgs = nixpkgsFor system;
           flakes = flakesFor pkgs k-framework.packages.${system}.k;
         in {
-          kore-rpc-booster =
-            packages."hs-backend-booster:exe:kore-rpc-booster";
+          kore-rpc-booster = packages."hs-backend-booster:exe:kore-rpc-booster";
           booster-dev = packages."hs-backend-booster:exe:booster-dev";
           rpc-client = packages."hs-backend-booster:exe:rpc-client";
           parsetest = packages."hs-backend-booster:exe:parsetest";
@@ -163,7 +155,8 @@
       apps = perSystem (system:
         let
           inherit (flakes.${defaultCompiler}) apps;
-          flakes = flakesFor (nixpkgsFor system) k-framework.packages.${system}.k;
+          flakes =
+            flakesFor (nixpkgsFor system) k-framework.packages.${system}.k;
           pkgs = nixpkgsFor system;
           scripts = pkgs.symlinkJoin {
             name = "scripts";
@@ -194,7 +187,9 @@
       # To enter a development environment for a particular GHC version, use
       # the compiler name, e.g. `nix develop .#ghc8107`
       devShells = perSystem (system:
-        let flakes = flakesFor (nixpkgsFor system) k-framework.packages.${system}.k;
+        let
+          flakes =
+            flakesFor (nixpkgsFor system) k-framework.packages.${system}.k;
         in {
           default = flakes.${defaultCompiler}.devShell;
         } // lib.attrsets.mapAttrs'
@@ -207,7 +202,9 @@
       #
       # `nix build .#ghc8107:hs-backend-booster:test:unit-tests`
       checks = perSystem (system:
-        let flakes = flakesFor (nixpkgsFor system) k-framework.packages.${system}.k;
+        let
+          flakes =
+            flakesFor (nixpkgsFor system) k-framework.packages.${system}.k;
         in flakes.${defaultCompiler}.checks // collectOutputs "checks" flakes
         // {
           integration = with nixpkgsFor system;
@@ -215,8 +212,7 @@
             callPackage ./test/rpc-integration {
               kore-rpc-booster =
                 packages."hs-backend-booster:exe:kore-rpc-booster";
-              rpc-client =
-                packages."hs-backend-booster:exe:rpc-client";
+              rpc-client = packages."hs-backend-booster:exe:rpc-client";
               inherit (k-framework.packages.${system}) k;
             };
         });
@@ -226,7 +222,10 @@
           lib.optionalAttrs (!(prev ? haskell-nix))
           (inputs.haskell-nix.overlays.combined final prev))
         (_: prev:
-          let inherit ((flakesFor prev k-framework.packages.${prev.system}.k).${defaultCompiler}) packages;
+          let
+            inherit ((flakesFor prev
+              k-framework.packages.${prev.system}.k).${defaultCompiler})
+              packages;
           in {
             kore-rpc-booster =
               packages."hs-backend-booster:exe:kore-rpc-booster";


### PR DESCRIPTION
fixes #204 

<img width="639" alt="image" src="https://github.com/runtimeverification/hs-backend-booster/assets/10553895/80201cfa-d76c-4679-88f4-4ccf256c4ec5">
