### PR TITLE
Be explicit about the argument type of a `Gen.element` call in the json generatora

### DIFF
--- a/unit-tests/Test/Booster/Syntax/Json.hs
+++ b/unit-tests/Test/Booster/Syntax/Json.hs
@@ -120,7 +120,7 @@ genIdChar =
     Gen.frequency
         [ (10, Gen.alpha)
         , (3, Gen.digit)
-        , (1, Gen.element "-'")
+        , (1, Gen.element ['-', '\''])
         ]
 
 genStringLiteral :: Gen Text


### PR DESCRIPTION
Following the  `hedgehog` fix for Cabal build from [haskell-backend](https://github.com/runtimeverification/haskell-backend/commit/55a2cb6cee5be7d897503557f25861b8e6c3f026)