### PR TITLE
Don't trace rewrites and equation applications if not requested

### DIFF
--- a/library/Booster/JsonRpc.hs
+++ b/library/Booster/JsonRpc.hs
@@ -83,7 +83,15 @@ respond stateVar =
                     let cutPoints = fromMaybe [] req.cutPointRules
                         terminals = fromMaybe [] req.terminalRules
                         mbDepth = fmap getNat req.maxDepth
-                    execResponse req <$> performRewrite def mLlvmLibrary mbDepth cutPoints terminals pat
+                        doTracing =
+                            any
+                                (fromMaybe False)
+                                [ req.logSuccessfulRewrites
+                                , req.logFailedRewrites
+                                , req.logSuccessfulSimplifications
+                                , req.logFailedSimplifications
+                                ]
+                    execResponse req <$> performRewrite doTracing def mLlvmLibrary mbDepth cutPoints terminals pat
         AddModule req -> do
             -- block other request executions while modifying the server state
             state <- liftIO $ takeMVar stateVar
@@ -126,6 +134,12 @@ respond stateVar =
                             . toList
                 logTraces =
                     mapM_ (Log.logOther (Log.LevelOther "Simplify") . pack . renderDefault . pretty)
+                doTracing =
+                    any
+                        (fromMaybe False)
+                        [ req.logSuccessfulSimplifications
+                        , req.logFailedSimplifications
+                        ]
             case internalised of
                 Left patternErrors -> do
                     Log.logError $ "Error internalising cterm: " <> Text.pack (show patternErrors)
@@ -133,7 +147,7 @@ respond stateVar =
                 -- term and predicate (pattern)
                 Right (TermAndPredicate Pattern{term, constraints}) -> do
                     Log.logInfoNS "booster" "Simplifying term of a pattern"
-                    case ApplyEquations.evaluateTerm ApplyEquations.TopDown def mLlvmLibrary term of
+                    case ApplyEquations.evaluateTerm doTracing ApplyEquations.TopDown def mLlvmLibrary term of
                         Right (newTerm, traces) -> do
                             logTraces $ filter (not . ApplyEquations.isMatchFailure) traces
                             let (t, p) = externalisePattern Pattern{constraints, term = newTerm}
@@ -151,7 +165,7 @@ respond stateVar =
                             -- predicate only
                 Right (APredicate predicate) -> do
                     Log.logInfoNS "booster" "Simplifying a predicate"
-                    case ApplyEquations.traceSimplifyConstraint def mLlvmLibrary predicate of
+                    case ApplyEquations.traceSimplifyConstraint doTracing def mLlvmLibrary predicate of
                         Right (newPred, traces) -> do
                             logTraces $ filter (not . ApplyEquations.isMatchFailure) traces
                             let predicateSort =

--- a/library/Booster/JsonRpc.hs
+++ b/library/Booster/JsonRpc.hs
@@ -165,7 +165,7 @@ respond stateVar =
                             -- predicate only
                 Right (APredicate predicate) -> do
                     Log.logInfoNS "booster" "Simplifying a predicate"
-                    case ApplyEquations.traceSimplifyConstraint doTracing def mLlvmLibrary predicate of
+                    case ApplyEquations.simplifyConstraint doTracing def mLlvmLibrary predicate of
                         Right (newPred, traces) -> do
                             logTraces $ filter (not . ApplyEquations.isMatchFailure) traces
                             let predicateSort =

--- a/library/Booster/Pattern/ApplyEquations.hs
+++ b/library/Booster/Pattern/ApplyEquations.hs
@@ -14,7 +14,6 @@ module Booster.Pattern.ApplyEquations (
     isMatchFailure,
     isSuccess,
     simplifyConstraint,
-    traceSimplifyConstraint,
 ) where
 
 import Control.Monad
@@ -530,18 +529,8 @@ simplifyConstraint ::
     KoreDefinition ->
     Maybe LLVM.API ->
     Predicate ->
-    Predicate
-simplifyConstraint doTracing def mbApi p =
-    either (const p) fst $ traceSimplifyConstraint doTracing def mbApi p
-
--- | Constraint simplification that collects a simplification trace
-traceSimplifyConstraint ::
-    Bool ->
-    KoreDefinition ->
-    Maybe LLVM.API ->
-    Predicate ->
     Either EquationFailure (Predicate, [EquationTrace])
-traceSimplifyConstraint doTracing def mbApi p =
+simplifyConstraint doTracing def mbApi p =
     runEquationM def mbApi doTracing $ simplifyConstraint' p
 
 -- version for internal nested evaluation

--- a/library/Booster/Pattern/ApplyEquations.hs
+++ b/library/Booster/Pattern/ApplyEquations.hs
@@ -170,13 +170,15 @@ data EquationPreference = PreferFunctions | PreferSimplifications
     deriving stock (Eq, Show)
 
 runEquationM ::
+    Bool ->
     KoreDefinition ->
     Maybe LLVM.API ->
-    Bool ->
     EquationM a ->
     Either EquationFailure (a, [EquationTrace])
-runEquationM definition llvmApi doTracing (EquationM m) =
-    fmap (fmap $ toList . trace) <$> runExcept . flip runReaderT EquationConfig{definition, llvmApi, doTracing} . runStateT m $ startState
+runEquationM doTracing definition llvmApi (EquationM m) =
+    fmap (fmap $ toList . trace)
+        <$> runExcept . flip runReaderT EquationConfig{definition, llvmApi, doTracing} . runStateT m
+        $ startState
 
 iterateEquations ::
     Int ->
@@ -213,7 +215,7 @@ evaluateTerm ::
     Term ->
     Either EquationFailure (Term, [EquationTrace])
 evaluateTerm doTracing direction def llvmApi =
-    runEquationM def llvmApi doTracing
+    runEquationM doTracing def llvmApi
         . iterateEquations 100 direction PreferFunctions
 
 ----------------------------------------
@@ -531,7 +533,7 @@ simplifyConstraint ::
     Predicate ->
     Either EquationFailure (Predicate, [EquationTrace])
 simplifyConstraint doTracing def mbApi p =
-    runEquationM def mbApi doTracing $ simplifyConstraint' p
+    runEquationM doTracing def mbApi $ simplifyConstraint' p
 
 -- version for internal nested evaluation
 simplifyConstraint' :: Predicate -> EquationM Predicate

--- a/library/Booster/Pattern/Rewrite.hs
+++ b/library/Booster/Pattern/Rewrite.hs
@@ -222,12 +222,12 @@ applyRule pat rule = runMaybeT $ do
         MaybeT (RewriteM (RewriteFailed k)) (Maybe a)
     checkConstraint onUnclear p = do
         RewriteConfig{definition, llvmApi, doTracing} <- lift $ RewriteM ask
-        liftIO $
-            simplifyConstraint doTracing definition llvmApi p >>= \case
-                Right (Bottom, _) -> fail "Rule condition was False"
-                Right (Top, _) -> pure Nothing
-                Right (other, _) -> pure $ Just $ onUnclear other
-                Left _ -> pure $ Just $ onUnclear p
+        simplified <- liftIO $ simplifyConstraint doTracing definition llvmApi p
+        case simplified of
+            Right (Bottom, _) -> fail "Rule condition was False"
+            Right (Top, _) -> pure Nothing
+            Right (other, _) -> pure $ Just $ onUnclear other
+            Left _ -> pure $ Just $ onUnclear p
 
 {- | Reason why a rewrite did not produce a result. Contains additional
    information for logging what happened during the rewrite.

--- a/library/Booster/Pattern/Rewrite.hs
+++ b/library/Booster/Pattern/Rewrite.hs
@@ -61,7 +61,10 @@ data RewriteConfig = RewriteConfig
     }
 
 runRewriteM :: Bool -> KoreDefinition -> Maybe LLVM.API -> RewriteM err a -> Either err a
-runRewriteM doTracing def mLlvmLibrary = runExcept . flip runReaderT RewriteConfig{definition = def, llvmApi = mLlvmLibrary, doTracing} . unRewriteM
+runRewriteM doTracing def mLlvmLibrary =
+    runExcept
+        . flip runReaderT RewriteConfig{definition = def, llvmApi = mLlvmLibrary, doTracing}
+        . unRewriteM
 
 throw :: err -> RewriteM err a
 throw = RewriteM . lift . throwE

--- a/library/Booster/Pattern/Rewrite.hs
+++ b/library/Booster/Pattern/Rewrite.hs
@@ -219,9 +219,10 @@ applyRule pat rule = runMaybeT $ do
     checkConstraint onUnclear p = do
         RewriteConfig{definition, llvmApi, doTracing} <- lift $ RewriteM ask
         case simplifyConstraint doTracing definition llvmApi p of
-            Bottom -> fail "Rule condition was False"
-            Top -> pure Nothing
-            other -> pure $ Just $ onUnclear other
+            Right (Bottom, _) -> fail "Rule condition was False"
+            Right (Top, _) -> pure Nothing
+            Right (other, _) -> pure $ Just $ onUnclear other
+            Left _ -> pure $ Just $ onUnclear p
 
 {- | Reason why a rewrite did not produce a result. Contains additional
    information for logging what happened during the rewrite.

--- a/unit-tests/Test/Booster/Pattern/ApplyEquations.hs
+++ b/unit-tests/Test/Booster/Pattern/ApplyEquations.hs
@@ -10,6 +10,7 @@ module Test.Booster.Pattern.ApplyEquations (
     test_errors,
 ) where
 
+import Control.Monad.Logger (runNoLoggingT)
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Text (Text)
@@ -77,7 +78,7 @@ test_evaluateFunction =
             -- eval BottomUp subj @?= Right result
         ]
   where
-    eval direction = fmap fst . unsafePerformIO . evaluateTerm False direction funDef Nothing
+    eval direction = fmap fst . unsafePerformIO . runNoLoggingT . evaluateTerm False direction funDef Nothing
     a = var "A" someSort
     d = dv someSort "hey"
     apply f = app f . (: [])
@@ -108,7 +109,7 @@ test_simplify =
             simpl BottomUp subj @?= Right result
         ]
   where
-    simpl direction = fmap fst . unsafePerformIO . evaluateTerm False direction simplDef Nothing
+    simpl direction = fmap fst . unsafePerformIO . runNoLoggingT . evaluateTerm False direction simplDef Nothing
     a = var "A" someSort
 
 test_errors :: TestTree
@@ -121,7 +122,7 @@ test_errors =
                 subj = f $ app con1 [a]
                 loopTerms =
                     [f $ app con1 [a], f $ app con2 [a], f $ app con3 [a, a], f $ app con1 [a]]
-            isLoop loopTerms . unsafePerformIO $ evaluateTerm False TopDown loopDef Nothing subj
+            isLoop loopTerms . unsafePerformIO . runNoLoggingT $ evaluateTerm False TopDown loopDef Nothing subj
         ]
   where
     isLoop ts (Left (EquationLoop _ ts')) = ts @?= ts'

--- a/unit-tests/Test/Booster/Pattern/ApplyEquations.hs
+++ b/unit-tests/Test/Booster/Pattern/ApplyEquations.hs
@@ -76,7 +76,7 @@ test_evaluateFunction =
             -- eval BottomUp subj @?= Right result
         ]
   where
-    eval direction = fmap fst . evaluateTerm direction funDef Nothing
+    eval direction = fmap fst . evaluateTerm False direction funDef Nothing
     a = var "A" someSort
     d = dv someSort "hey"
     apply f = app f . (: [])
@@ -107,7 +107,7 @@ test_simplify =
             simpl BottomUp subj @?= Right result
         ]
   where
-    simpl direction = fmap fst . evaluateTerm direction simplDef Nothing
+    simpl direction = fmap fst . evaluateTerm False direction simplDef Nothing
     a = var "A" someSort
 
 test_errors :: TestTree
@@ -120,7 +120,7 @@ test_errors =
                 subj = f $ app con1 [a]
                 loopTerms =
                     [f $ app con1 [a], f $ app con2 [a], f $ app con3 [a, a], f $ app con1 [a]]
-            isLoop loopTerms $ evaluateTerm TopDown loopDef Nothing subj
+            isLoop loopTerms $ evaluateTerm False TopDown loopDef Nothing subj
         ]
   where
     isLoop ts (Left (EquationLoop _ ts')) = ts @?= ts'

--- a/unit-tests/Test/Booster/Pattern/ApplyEquations.hs
+++ b/unit-tests/Test/Booster/Pattern/ApplyEquations.hs
@@ -13,6 +13,7 @@ module Test.Booster.Pattern.ApplyEquations (
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Text (Text)
+import GHC.IO.Unsafe (unsafePerformIO)
 import Test.Tasty
 import Test.Tasty.HUnit
 
@@ -76,7 +77,7 @@ test_evaluateFunction =
             -- eval BottomUp subj @?= Right result
         ]
   where
-    eval direction = fmap fst . evaluateTerm False direction funDef Nothing
+    eval direction = fmap fst . unsafePerformIO . evaluateTerm False direction funDef Nothing
     a = var "A" someSort
     d = dv someSort "hey"
     apply f = app f . (: [])
@@ -107,7 +108,7 @@ test_simplify =
             simpl BottomUp subj @?= Right result
         ]
   where
-    simpl direction = fmap fst . evaluateTerm False direction simplDef Nothing
+    simpl direction = fmap fst . unsafePerformIO . evaluateTerm False direction simplDef Nothing
     a = var "A" someSort
 
 test_errors :: TestTree
@@ -120,7 +121,7 @@ test_errors =
                 subj = f $ app con1 [a]
                 loopTerms =
                     [f $ app con1 [a], f $ app con2 [a], f $ app con3 [a, a], f $ app con1 [a]]
-            isLoop loopTerms $ evaluateTerm False TopDown loopDef Nothing subj
+            isLoop loopTerms . unsafePerformIO $ evaluateTerm False TopDown loopDef Nothing subj
         ]
   where
     isLoop ts (Left (EquationLoop _ ts')) = ts @?= ts'

--- a/unit-tests/Test/Booster/Pattern/Rewrite.hs
+++ b/unit-tests/Test/Booster/Pattern/Rewrite.hs
@@ -15,6 +15,7 @@ import Data.List.NonEmpty qualified as NE
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Text (Text)
+import GHC.IO.Unsafe (unsafePerformIO)
 import Numeric.Natural
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -252,18 +253,18 @@ rulePriority =
 
 rewritesTo :: Term -> (Text, Term) -> IO ()
 t1 `rewritesTo` (lbl, t2) =
-    runRewriteM False def Nothing (rewriteStep [] [] $ Pattern t1 [])
+    unsafePerformIO (runRewriteM False def Nothing (rewriteStep [] [] $ Pattern t1 []))
         @?= Right (RewriteFinished (Just lbl) Nothing $ Pattern t2 [])
 
 branchesTo :: Term -> [(Text, Term)] -> IO ()
 t `branchesTo` ts =
-    runRewriteM False def Nothing (rewriteStep [] [] $ Pattern t [])
+    unsafePerformIO (runRewriteM False def Nothing (rewriteStep [] [] $ Pattern t []))
         @?= Right
             (RewriteBranch (Pattern t []) $ NE.fromList $ map (\(lbl, t') -> (lbl, Nothing, Pattern t' [])) ts)
 
 failsWith :: Term -> RewriteFailed "Rewrite" -> IO ()
 failsWith t err =
-    runRewriteM False def Nothing (rewriteStep [] [] $ Pattern t []) @?= Left err
+    unsafePerformIO (runRewriteM False def Nothing (rewriteStep [] [] $ Pattern t [])) @?= Left err
 
 ----------------------------------------
 -- tests for performRewrite (iterated rewrite in IO with logging)

--- a/unit-tests/Test/Booster/Pattern/Rewrite.hs
+++ b/unit-tests/Test/Booster/Pattern/Rewrite.hs
@@ -253,18 +253,19 @@ rulePriority =
 
 rewritesTo :: Term -> (Text, Term) -> IO ()
 t1 `rewritesTo` (lbl, t2) =
-    unsafePerformIO (runRewriteM False def Nothing (rewriteStep [] [] $ Pattern t1 []))
+    unsafePerformIO (runNoLoggingT $ runRewriteT False def Nothing (rewriteStep [] [] $ Pattern t1 []))
         @?= Right (RewriteFinished (Just lbl) Nothing $ Pattern t2 [])
 
 branchesTo :: Term -> [(Text, Term)] -> IO ()
 t `branchesTo` ts =
-    unsafePerformIO (runRewriteM False def Nothing (rewriteStep [] [] $ Pattern t []))
+    unsafePerformIO (runNoLoggingT $ runRewriteT False def Nothing (rewriteStep [] [] $ Pattern t []))
         @?= Right
             (RewriteBranch (Pattern t []) $ NE.fromList $ map (\(lbl, t') -> (lbl, Nothing, Pattern t' [])) ts)
 
 failsWith :: Term -> RewriteFailed "Rewrite" -> IO ()
 failsWith t err =
-    unsafePerformIO (runRewriteM False def Nothing (rewriteStep [] [] $ Pattern t [])) @?= Left err
+    unsafePerformIO (runNoLoggingT $ runRewriteT False def Nothing (rewriteStep [] [] $ Pattern t []))
+        @?= Left err
 
 ----------------------------------------
 -- tests for performRewrite (iterated rewrite in IO with logging)

--- a/unit-tests/Test/Booster/Pattern/Rewrite.hs
+++ b/unit-tests/Test/Booster/Pattern/Rewrite.hs
@@ -193,18 +193,18 @@ errorCases =
                     [trm| kCell{}( kseq{}( inj{SomeSort{}, SortKItem{}}( con2{}( \dv{SomeSort{}}("thing") ) ), Thing:SortK{}) ) |]
         , testCase "Index is None" $ do
             let t =
-                    [trm| 
-                        kCell{}( 
-                            kseq{}( 
-                                inj{SomeSort{}, SortKItem{}}( 
-                                    \and{SomeSort{}}( 
-                                        con1{}( \dv{SomeSort{}}("thing") ), 
+                    [trm|
+                        kCell{}(
+                            kseq{}(
+                                inj{SomeSort{}, SortKItem{}}(
+                                    \and{SomeSort{}}(
+                                        con1{}( \dv{SomeSort{}}("thing") ),
                                         con2{}( \dv{SomeSort{}}("thing") )
                                     )
-                                ), 
+                                ),
                                 Thing:SortK{}
                             )
-                        ) 
+                        )
                     |]
             t `failsWith` TermIndexIsNone t
         ]
@@ -252,25 +252,25 @@ rulePriority =
 
 rewritesTo :: Term -> (Text, Term) -> IO ()
 t1 `rewritesTo` (lbl, t2) =
-    runRewriteM def Nothing (rewriteStep [] [] $ Pattern t1 [])
+    runRewriteM False def Nothing (rewriteStep [] [] $ Pattern t1 [])
         @?= Right (RewriteFinished (Just lbl) Nothing $ Pattern t2 [])
 
 branchesTo :: Term -> [(Text, Term)] -> IO ()
 t `branchesTo` ts =
-    runRewriteM def Nothing (rewriteStep [] [] $ Pattern t [])
+    runRewriteM False def Nothing (rewriteStep [] [] $ Pattern t [])
         @?= Right
             (RewriteBranch (Pattern t []) $ NE.fromList $ map (\(lbl, t') -> (lbl, Nothing, Pattern t' [])) ts)
 
 failsWith :: Term -> RewriteFailed "Rewrite" -> IO ()
 failsWith t err =
-    runRewriteM def Nothing (rewriteStep [] [] $ Pattern t []) @?= Left err
+    runRewriteM False def Nothing (rewriteStep [] [] $ Pattern t []) @?= Left err
 
 ----------------------------------------
 -- tests for performRewrite (iterated rewrite in IO with logging)
 
 runRewrite :: Term -> IO (Natural, RewriteResult Term)
 runRewrite t = do
-    (counter, _, res) <- runNoLoggingT $ performRewrite def Nothing Nothing [] [] $ Pattern t []
+    (counter, _, res) <- runNoLoggingT $ performRewrite False def Nothing Nothing [] [] $ Pattern t []
     pure (counter, fmap (.term) res)
 
 aborts :: Term -> IO ()
@@ -398,7 +398,7 @@ supportsDepthControl =
   where
     rewritesToDepth :: MaxDepth -> Steps -> Term -> t -> (t -> RewriteResult Term) -> IO ()
     rewritesToDepth (MaxDepth depth) (Steps n) t t' f = do
-        (counter, _, res) <- runNoLoggingT $ performRewrite def Nothing (Just depth) [] [] $ Pattern t []
+        (counter, _, res) <- runNoLoggingT $ performRewrite False def Nothing (Just depth) [] [] $ Pattern t []
         (counter, fmap (.term) res) @?= (n, f t')
 
 supportsCutPoints :: TestTree
@@ -445,7 +445,7 @@ supportsCutPoints =
   where
     rewritesToCutPoint :: Text -> Steps -> Term -> t -> (t -> RewriteResult Term) -> IO ()
     rewritesToCutPoint lbl (Steps n) t t' f = do
-        (counter, _, res) <- runNoLoggingT $ performRewrite def Nothing Nothing [lbl] [] $ Pattern t []
+        (counter, _, res) <- runNoLoggingT $ performRewrite False def Nothing Nothing [lbl] [] $ Pattern t []
         (counter, fmap (.term) res) @?= (n, f t')
 
 supportsTerminalRules :: TestTree
@@ -470,5 +470,5 @@ supportsTerminalRules =
   where
     rewritesToTerminal :: Text -> Steps -> Term -> t -> (t -> RewriteResult Term) -> IO ()
     rewritesToTerminal lbl (Steps n) t t' f = do
-        (counter, _, res) <- runNoLoggingT $ performRewrite def Nothing Nothing [] [lbl] $ Pattern t []
+        (counter, _, res) <- runNoLoggingT $ performRewrite False def Nothing Nothing [] [lbl] $ Pattern t []
         (counter, fmap (.term) res) @?= (n, f t')


### PR DESCRIPTION
Fixes #224 and #126

* Refactor `EquatioM` to `EquationT`
  - make it a monad transformer
  - Move immutable data to a `ReaderT`
  - Add `MonadLoggerIO` constraint on interface functions
* Refactor `RewriteM` to `RewriteT`
  - make it a monad transformer
  - Make the reader config a proper product type, rather then a tuple
  - Add `MonadLoggerIO` constraint on interface functions
* Thread tracing flag down to rewrites and equation applications. Only accumulate traces if the flag is set.

Currently, the `doTracing` flag is less granular than the RPC request tracing options: we will collect all traces if any of the four RPC options is set. We should probably address this in a follow-up PR.