### PR TITLE
.github/release: automatically publish releases

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,26 @@
+name: "Release"
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+
+  update-dependents:
+    name: 'Publish Release'
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: 'Update dependents'
+        env:
+          GITHUB_TOKEN: ${{ secrets.JENKINS_GITHUB_PAT }}
+        run: |
+          set -x
+          version="${GITHUB_SHA}"
+          curl --fail                                                          \
+            -X POST                                                            \
+            -H "Accept: application/vnd.github+json"                           \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}"                         \
+            -H "X-GitHub-Api-Version: 2022-11-28"                              \
+            https://api.github.com/repos/runtimeverification/devops/dispatches \
+            -d '{"event_type":"on-demand-test","client_payload":{"repo":"runtimeverification/hs-backend-booster","version":"'${version}'"}}'


### PR DESCRIPTION
This PR automatically publishes releases.

- The devops repo has been updated to know what to do with these releases: https://github.com/runtimeverification/devops/commit/03af53c1a9b872be84f81c6345a0e9a03a489b6e
- We have a branch open against K for testing that the publishing is working correctly: https://github.com/runtimeverification/k/pull/3502.