### PR TITLE
Accept auto-updates from haskell backend repo

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -1,0 +1,50 @@
+name: 'Update Nix Flake Inputs'
+on:
+  push:
+    branches:
+      - '_update-deps/runtimeverification/haskell-backend'
+  workflow_dispatch:
+# Stop in progress workflows on the same branch and same workflow to use latest committed code
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  nix-flake-submodule-sync:
+    name: 'Nix flake submodule sync'
+    runs-on: ubuntu-20.04
+    steps:
+      - name: 'Check out code, set up Git'
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.JENKINS_GITHUB_PAT }}
+          submodules: recursive
+      - run: |
+          git config --global user.name rv-jenkins
+          git config --global user.email devops@runtimeverification.com
+
+      - name: 'Install Nix'
+        uses: cachix/install-nix-action@v22
+        with:
+          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+            substituters = http://cache.nixos.org https://hydra.iohk.io
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
+
+      - name: 'Install Cachix'
+        uses: cachix/cachix-action@v12
+        with:
+          name: k-framework
+          authToken: '${{ secrets.CACHIX_PUBLIC_TOKEN }}'
+
+      - name: 'Update Nix flake inputs from submodules/release-tags'
+        run: |
+          set -euxo pipefail
+          haskell_backend_version=$(cat deps/haskell-backend_release)
+          sed -i 's!    haskell-backend.url = "github:runtimeverification/haskell-backend/[0-9a-f]*";!    haskell-backend.url = "github:runtimeverification/haskell-backend/'${haskell_backend_version}'";' flake.nix
+          nix flake update
+          if git add flake.nix flake.lock && git commit -m 'Sync flake inputs to submodules'; then
+            git push
+          fi

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -46,14 +46,12 @@ jobs:
 
           haskell_backend_version=$(cat deps/haskell-backend_release)
           sed -i 's!    haskell-backend.url = "github:runtimeverification/haskell-backend/[0-9a-f]*";!    haskell-backend.url = "github:runtimeverification/haskell-backend/'${haskell_backend_version}'";!' flake.nix
-          if git add flake.nix; then
-            git commit -m "flake.nix: update haskell-backend to version ${haskell_backend_version}"
+          if git add flake.nix && git commit -m "flake.nix: update haskell-backend to version ${haskell_backend_version}"; then
             changed=true
           fi
 
           nix flake update
-          if git add flake.lock; then
-            git commit -m 'flake.lock: update'
+          if git add flake.lock && git commit -m 'flake.lock: update'; then
             changed=true
           fi
 

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -39,12 +39,24 @@ jobs:
           name: k-framework
           authToken: '${{ secrets.CACHIX_PUBLIC_TOKEN }}'
 
-      - name: 'Update Nix flake inputs from submodules/release-tags'
+      - name: 'Update Nix flake from haskell backend release tag'
         run: |
           set -euxo pipefail
+          changed=false
+
           haskell_backend_version=$(cat deps/haskell-backend_release)
           sed -i 's!    haskell-backend.url = "github:runtimeverification/haskell-backend/[0-9a-f]*";!    haskell-backend.url = "github:runtimeverification/haskell-backend/'${haskell_backend_version}'";!' flake.nix
+          if git add flake.nix; then
+            git commit -m "flake.nix: update haskell-backend to version ${haskell_backend_version}"
+            changed=true
+          fi
+
           nix flake update
-          if git add flake.nix flake.lock && git commit -m 'Sync flake inputs to submodules'; then
+          if git add flake.lock; then
+            git commit -m 'flake.lock: update'
+            changed=true
+          fi
+
+          if ${changed}; then
             git push
           fi

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           set -euxo pipefail
           haskell_backend_version=$(cat deps/haskell-backend_release)
-          sed -i 's!    haskell-backend.url = "github:runtimeverification/haskell-backend/[0-9a-f]*";!    haskell-backend.url = "github:runtimeverification/haskell-backend/'${haskell_backend_version}'";' flake.nix
+          sed -i 's!    haskell-backend.url = "github:runtimeverification/haskell-backend/[0-9a-f]*";!    haskell-backend.url = "github:runtimeverification/haskell-backend/'${haskell_backend_version}'";!' flake.nix
           nix flake update
           if git add flake.nix flake.lock && git commit -m 'Sync flake inputs to submodules'; then
             git push

--- a/deps/haskell-backend_release
+++ b/deps/haskell-backend_release
@@ -1,0 +1,1 @@
+a6230144a37ee9ebf0f6dffc849faf5ce10df380

--- a/flake.lock
+++ b/flake.lock
@@ -450,6 +450,7 @@
       "original": {
         "owner": "runtimeverification",
         "repo": "haskell-backend",
+        "rev": "a6230144a37ee9ebf0f6dffc849faf5ce10df380",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     k-framework.url = "github:runtimeverification/k/v5.6.131";
-    haskell-backend.url = "github:runtimeverification/haskell-backend/abcd";
+    haskell-backend.url = "github:runtimeverification/haskell-backend/a6230144a37ee9ebf0f6dffc849faf5ce10df380";
     k-framework.inputs.booster-backend.follows = "";
     haskell-nix.follows = "haskell-backend/haskell-nix";
     nixpkgs.follows = "haskell-backend/haskell-nix/nixpkgs-unstable";

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     k-framework.url = "github:runtimeverification/k/v5.6.131";
-    haskell-backend.url = "github:runtimeverification/haskell-backend";
+    haskell-backend.url = "github:runtimeverification/haskell-backend/abcd";
     k-framework.inputs.booster-backend.follows = "";
     haskell-nix.follows = "haskell-backend/haskell-nix";
     nixpkgs.follows = "haskell-backend/haskell-nix/nixpkgs-unstable";


### PR DESCRIPTION
This sets it up so that the booster can accept automatic updates from the haskell backend repo.

- A new file `deps/haskell-backend_release` is added pinning the release tag.
- The file `.github/workflows/update-deps.yml` is added to sync the nix flake build for this submodule.

This is to be paired with a PR into K which shifts it to sourcing the Haskell backend from the booster repo (https://github.com/runtimeverification/k/pull/3514).