### PR TITLE
Reshuffle the EquationT transformer stack

### DIFF
--- a/unit-tests/Test/Booster/Pattern/ApplyEquations.hs
+++ b/unit-tests/Test/Booster/Pattern/ApplyEquations.hs
@@ -87,7 +87,7 @@ test_evaluateFunction =
             eval BottomUp subj @?= Right result
         ]
   where
-    eval direction = fmap fst . unsafePerformIO . runNoLoggingT . evaluateTerm False direction funDef Nothing
+    eval direction = unsafePerformIO . runNoLoggingT . (fst <$>) . evaluateTerm False direction funDef Nothing
 
     isTooManyIterations (Left (TooManyIterations _n _ _)) = pure ()
     isTooManyIterations (Left err) = assertFailure $ "Unexpected error " <> show err
@@ -114,7 +114,7 @@ test_simplify =
             simpl BottomUp subj @?= Right result
         ]
   where
-    simpl direction = fmap fst . unsafePerformIO . runNoLoggingT . evaluateTerm False direction simplDef Nothing
+    simpl direction = unsafePerformIO . runNoLoggingT . (fst <$>) . evaluateTerm False direction simplDef Nothing
     a = var "A" someSort
 
 test_simplifyPattern :: TestTree
@@ -143,7 +143,7 @@ test_simplifyPattern =
             simpl subj @?= Right result
         ]
   where
-    simpl = fmap fst . unsafePerformIO . runNoLoggingT . evaluatePattern False simplDef Nothing
+    simpl = unsafePerformIO . runNoLoggingT . (fst <$>) . evaluatePattern False simplDef Nothing
     a = var "A" someSort
 
 test_errors :: TestTree
@@ -156,10 +156,11 @@ test_errors =
                 subj = f $ app con1 [a]
                 loopTerms =
                     [f $ app con1 [a], f $ app con2 [a], f $ app con3 [a, a], f $ app con1 [a]]
-            isLoop loopTerms . unsafePerformIO . runNoLoggingT $ evaluateTerm False TopDown loopDef Nothing subj
+            isLoop loopTerms . unsafePerformIO . runNoLoggingT $
+                fst <$> evaluateTerm False TopDown loopDef Nothing subj
         ]
   where
-    isLoop ts (Left (EquationLoop _ ts')) = ts @?= ts'
+    isLoop ts (Left (EquationLoop ts')) = ts @?= ts'
     isLoop _ (Left err) = assertFailure $ "Unexpected error " <> show err
     isLoop _ (Right r) = assertFailure $ "Unexpected result " <> show r
 


### PR DESCRIPTION
Fixes https://github.com/runtimeverification/hs-backend-booster/issues/236 by reshuffling the `EquationT` transformer, currently defined as

```Haskell
newtype EquationT io a
    = EquationT (StateT EquationState (ReaderT EquationConfig (ExceptT EquationFailure io)) a)
 -- ~ EquationState -> EquationConfig -> io (Either EquationFailure (a, EquationState))
```

into 

```Haskell
newtype EquationT io a
    = EquationT (ReaderT EquationConfig (ExceptT EquationFailure (StateT EquationState io)) a)
 -- ~ EquationConfig -> EquationState -> io (Either EquationFailure a, EquationState)
```

This ensures that we always return the state even after a failed computation, hence we don't need to include the traces as data within the `EquationFailure`