### PR TITLE
Allow re-adding an already imported module

### DIFF
--- a/library/Booster/Syntax/ParsedKore/Internalise.hs
+++ b/library/Booster/Syntax/ParsedKore/Internalise.hs
@@ -91,11 +91,8 @@ addToDefinitions ::
     ParsedModule ->
     Map Text KoreDefinition ->
     Except DefinitionError (Map Text KoreDefinition)
-addToDefinitions m prior
-    | Map.member m.name.getId prior =
-        throwE $ DuplicateModule m.name.getId
-    | otherwise = do
-        definitionMap <$> execStateT (descendFrom m.name.getId) currentState
+addToDefinitions m prior =
+    definitionMap <$> execStateT (descendFrom m.name.getId) currentState
   where
     currentState =
         State


### PR DESCRIPTION
Fixes  #267

This change should allow pyk to launch a single server instance and run multiple proofs on the same instance, which involves each proof instance sending (potentially) the same add-module command to the server multiple times.