### PR TITLE
disable error for duplicate module

### DIFF
--- a/library/Booster/Syntax/ParsedKore/Internalise.hs
+++ b/library/Booster/Syntax/ParsedKore/Internalise.hs
@@ -91,11 +91,8 @@ addToDefinitions ::
     ParsedModule ->
     Map Text KoreDefinition ->
     Except DefinitionError (Map Text KoreDefinition)
-addToDefinitions m prior
-    | Map.member m.name.getId prior =
-        throwE $ DuplicateModule m.name.getId
-    | otherwise = do
-        definitionMap <$> execStateT (descendFrom m.name.getId) currentState
+addToDefinitions m prior = do
+    definitionMap <$> execStateT (descendFrom m.name.getId) currentState
   where
     currentState =
         State


### PR DESCRIPTION
This PR brings the booster in alignment with the old backend by allowing new modules with a particular name to replace old modules with the same name. We may want to separately consider changing both to only allow existing modules if they are identical to the old module, but I believe that this should be done as a single step to both backends once we confirm this is the desired behavior, rather than trying to apply the change piecemeal when the backends differ in behavior to start with.