### PR TITLE
Call free on `char*` pointer returned by `kore_simplify`

### DIFF
--- a/library/Booster/LLVM/Internal.hs
+++ b/library/Booster/LLVM/Internal.hs
@@ -342,7 +342,9 @@ mkAPI dlib = flip runReaderT dlib $ do
                                         }
                                 len <- fromIntegral <$> peek lenPtr
                                 cstr <- peek strPtr
-                                BS.packCStringLen (cstr, len)
+                                result <- BS.packCStringLen (cstr, len)
+                                Foreign.free cstr
+                                pure result
 
     pure API{patt, symbol, sort, simplifyBool, simplify}
   where


### PR DESCRIPTION
This is a cherry-pick from #263 that we could merge much faster without investigating LLVM backend bindings.