### PR TITLE
Simplify execution results more aggressively

### DIFF
--- a/tools/booster/Proxy.hs
+++ b/tools/booster/Proxy.hs
@@ -159,12 +159,16 @@ respondEither mbStatsVar booster kore req = case req of
         (bResult, bTime) <- withTime $ booster (Execute r{maxDepth = mbDepthLimit})
         case bResult of
             Right (Execute boosterResult)
-                -- if the new backend aborts or gets stuck, revert to the old one
+                -- if the new backend aborts, gets stuck or branches, revert to the old one
                 --
                 -- if we are stuck in the new backend we try to re-run
                 -- in the old one to work around any potential
                 -- unification bugs.
-                | boosterResult.reason `elem` [Aborted, Stuck] -> do
+                --
+                -- if we branch in the new backend we try to re-run
+                -- in the old one to see if the branch can be eliminated
+                -- using old backend's powerful simplifier
+                | boosterResult.reason `elem` [Aborted, Stuck, Branching] -> do
                     -- attempt to do one step in the old backend
                     Log.logInfoNS "proxy" . Text.pack $
                         "Booster " <> show boosterResult.reason <> " at " <> show boosterResult.depth

--- a/tools/booster/Proxy.hs
+++ b/tools/booster/Proxy.hs
@@ -160,16 +160,12 @@ respondEither mbStatsVar simplifyAfterExec booster kore req = case req of
         (bResult, bTime) <- withTime $ booster (Execute r{maxDepth = mbDepthLimit})
         case bResult of
             Right (Execute boosterResult)
-                -- if the new backend aborts, gets stuck or branches, revert to the old one
+                -- if the new backend aborts or gets stuck, revert to the old one
                 --
                 -- if we are stuck in the new backend we try to re-run
                 -- in the old one to work around any potential
                 -- unification bugs.
-                --
-                -- if we branch in the new backend we try to re-run
-                -- in the old one to see if the branch can be eliminated
-                -- using old backend's powerful simplifier
-                | boosterResult.reason `elem` [Aborted, Stuck, Branching] -> do
+                | boosterResult.reason `elem` [Aborted, Stuck] -> do
                     -- attempt to do one step in the old backend
                     Log.logInfoNS "proxy" . Text.pack $
                         "Booster " <> show boosterResult.reason <> " at " <> show boosterResult.depth

--- a/tools/booster/Proxy.hs
+++ b/tools/booster/Proxy.hs
@@ -284,10 +284,7 @@ respondEither mbStatsVar simplifyAfterExec booster kore req = case req of
     postExecSimplify mbModule
         | not simplifyAfterExec = pure
         | otherwise = \case
-            Execute res ->
-                case res.reason of
-                    Branching -> Execute <$> simplifyResult res
-                    _ -> pure (Execute res)
+            Execute res -> Execute <$> simplifyResult res
             other -> pure other
       where
         simplifyResult :: ExecuteResult -> m ExecuteResult

--- a/tools/booster/Proxy.hs
+++ b/tools/booster/Proxy.hs
@@ -199,6 +199,16 @@ respondEither mbStatsVar simplifyAfterExec booster kore req = case req of
                                     , koreTime + kTime
                                     )
                                     r{ExecuteRequest.state = execStateToKoreJson koreResult.state}
+                            | koreResult.reason == Branching -> do
+                                Log.logInfoNS "proxy" . Text.pack $
+                                    "Kore " <> show koreResult.reason <> ". " <> "Attempting to simplify the pre-state and continue..."
+                                simplifiedPreBranchState <- runSimplify Nothing koreResult.state
+                                loop
+                                    ( currentDepth + boosterResult.depth + koreResult.depth
+                                    , time + bTime + kTime
+                                    , koreTime + kTime
+                                    )
+                                    r{ExecuteRequest.state = execStateToKoreJson simplifiedPreBranchState}
                             | otherwise -> do
                                 -- otherwise we have hit a different
                                 -- HaltReason, at which point we should

--- a/tools/booster/Proxy.hs
+++ b/tools/booster/Proxy.hs
@@ -159,16 +159,12 @@ respondEither mbStatsVar booster kore req = case req of
         (bResult, bTime) <- withTime $ booster (Execute r{maxDepth = mbDepthLimit})
         case bResult of
             Right (Execute boosterResult)
-                -- if the new backend aborts, gets stuck or branches, revert to the old one
+                -- if the new backend aborts or gets stuck, revert to the old one
                 --
                 -- if we are stuck in the new backend we try to re-run
                 -- in the old one to work around any potential
                 -- unification bugs.
-                --
-                -- if we branch in the new backend we try to re-run
-                -- in the old one to see if the branch can be eliminated
-                -- using old backend's powerful simplifier
-                | boosterResult.reason `elem` [Aborted, Stuck, Branching] -> do
+                | boosterResult.reason `elem` [Aborted, Stuck] -> do
                     -- attempt to do one step in the old backend
                     Log.logInfoNS "proxy" . Text.pack $
                         "Booster " <> show boosterResult.reason <> " at " <> show boosterResult.depth

--- a/tools/booster/Proxy.hs
+++ b/tools/booster/Proxy.hs
@@ -284,7 +284,10 @@ respondEither mbStatsVar booster kore req = case req of
 
     postExecSimplify :: Maybe Text -> API 'Res -> m (API 'Res)
     postExecSimplify mbModule = \case
-        Execute res -> Execute <$> simplifyResult res
+        Execute res ->
+            case res.reason of
+                Branching -> Execute <$> simplifyResult res
+                _ -> pure (Execute res)
         other -> pure other
       where
         simplifyResult :: ExecuteResult -> m ExecuteResult

--- a/tools/booster/Server.hs
+++ b/tools/booster/Server.hs
@@ -85,7 +85,7 @@ main = do
                     , eventlogEnabledUserEvents
                     }
             , koreSolverOptions
-            , proxyOptions = ProxyOptions{printStats, simplifyAfterExec}
+            , proxyOptions = ProxyOptions{printStats}
             , debugSolverOptions
             } = options
         (logLevel, customLevels) = adjustLogLevels logLevels
@@ -142,7 +142,7 @@ main = do
                         server =
                             jsonRpcServer
                                 srvSettings
-                                (const $ Proxy.respondEither statVar simplifyAfterExec boosterRespond koreRespond)
+                                (const $ Proxy.respondEither statVar boosterRespond koreRespond)
                                 [handleErrorCall, handleSomeException]
                         interruptHandler _ = do
                             when (logLevel >= LevelInfo) $
@@ -177,11 +177,9 @@ data CLProxyOptions = CLProxyOptions
     , debugSolverOptions :: !Log.DebugSolverOptions
     }
 
-data ProxyOptions = ProxyOptions
+newtype ProxyOptions = ProxyOptions
     { printStats :: Bool
     -- ^ print timing statistics per request and on shutdown
-    , simplifyAfterExec :: Bool
-    -- ^ run kore simplifier on all result terms after executing
     }
 
 parserInfoModifiers :: InfoMod options
@@ -202,10 +200,6 @@ clProxyOptionsParser =
             <$> switch
                 ( long "print-stats"
                     <> help "(development) Print timing information per request and on shutdown"
-                )
-            <*> switch
-                ( long "simplify-after-exec"
-                    <> help "(experimental) Run kore simplifier on execute results before returning"
                 )
 
 mkKoreServer :: Log.LoggerEnv IO -> CLOptions -> KoreSolverOptions -> IO KoreServer


### PR DESCRIPTION
This PR strengthens `kore-rpc-booster`'s `execute` endpoint in one specific scenario:

**Scenario before**:
1. Booster aborts and reverts to Kore with depth 1
2. Kore takes one step and immediately branches
3. `kore-rpc-booster` returns the `Branching` response

**Scenario now**:
1. Booster aborts and reverts to Kore with depth 1
2. Kore takes one step and immediately branches
3. We simplify the pre-branch state that Kore returned using Kore's `simplify` endpoint 
4. We continue rewriting in Booster and making progress

My conjecture is that we'll be able to resolve many spurious branches this way.

Additionally, we now always `simplify` using Kore the execution results before responding with them. This is the behavior of `--simplify-after-exec` which we now think should be standard.

**Note**: it seems weird to me that Kore branches in the first place. After simplifying the pre-branch state with Kore, which Kore supposedly does anyway, we are able to make progress with the Booster.