### PR TITLE
Remove `[structural]` attribute from IMP integration tests

### DIFF
--- a/test/rpc-integration/resources/imp.k
+++ b/test/rpc-integration/resources/imp.k
@@ -64,23 +64,23 @@ module IMP
   rule true && B => B
   rule false && _ => false
 
-  rule {} => .   [structural]
-  rule {S} => S  [structural]
+  rule {} => .
+  rule {S} => S
 
   // rule <k> X = I:Int; => . ...</k> <state>... X |-> (_ => I) ...</state>
   rule <k> X = I:Int; => . ...</k> <state> M => M [ X <- I ] </state>
 
-  rule S1:Stmt S2:Stmt => S1 ~> S2  [structural]
+  rule S1:Stmt S2:Stmt => S1 ~> S2
 
   rule if (true)  S else _ => S
   rule if (false) _ else S => S
 
-  rule while (B) S => if (B) {S while (B) S} else {}  [structural]
+  rule while (B) S => if (B) {S while (B) S} else {}
 
   // rule <k> int (X,Xs => Xs);_ </k> <state> Rho:Map (.Map => X|->0) </state>
   rule <k> int (X,Xs => Xs);_ </k> <state> M => M [ X <- 0 ] </state>
     requires notBool (X in keys(M))
-  rule int .Ids; S => S ~> Stop() [structural]
+  rule int .Ids; S => S ~> Stop()
 
   syntax KItem ::= Stop()
   rule [stop]: <k> Stop() => . </k>


### PR DESCRIPTION
A PR into K (https://github.com/runtimeverification/k/pull/3592) removed this attribute. I've got a K-frontend compilation error locally with kup-installed K. As we use a slightly older K in CI, we will not yet see this, but eventually we will.