### PR TITLE
303 return vacuous when fallback simplifies to bottom

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -215,14 +215,14 @@ jobs:
           PLUGIN_VERSION=$(cat deps/blockchain-k-plugin_release)
           export PATH="$(nix build github:runtimeverification/k/v$K_VERSION#k.openssl.procps --no-link --json | $JQ -r '.[].outputs | to_entries[].value')/bin:$PATH"
           nix run .#hs-backend-booster:test:llvm-integration --extra-experimental-features 'nix-command flakes' --print-build-logs
-          
+
           # The runDirectoryTest.sh script expects the following env vars to be set
           export PLUGIN_DIR=$(nix build github:runtimeverification/blockchain-k-plugin/$PLUGIN_VERSION --no-link --json | $JQ -r '.[].outputs | to_entries[].value')
           KORE_RPC_BOOSTER=$(nix build .#kore-rpc-booster --no-link --json | $JQ -r '.[].outputs | to_entries[].value')/bin/kore-rpc-booster
           BOOSTER_DEV=$(nix build .#hs-backend-booster:exe:booster-dev --no-link --json | $JQ -r '.[].outputs | to_entries[].value')/bin/booster-dev
           KORE_RPC_DEV=$(nix build .#hs-backend-booster:exe:kore-rpc-dev --no-link --json | $JQ -r '.[].outputs | to_entries[].value')/bin/kore-rpc-dev
           export CLIENT=$(nix build .#hs-backend-booster:exe:rpc-client --no-link --json | $JQ -r '.[].outputs | to_entries[].value')/bin/rpc-client
-          
+
           cd test/rpc-integration
           for dir in $(ls -d test-*); do
               name=${dir##test-}
@@ -231,6 +231,9 @@ jobs:
                   SERVER=$BOOSTER_DEV ./runDirectoryTest.sh test-$name --time
                   SERVER=$KORE_RPC_DEV ./runDirectoryTest.sh test-$name --time
                   SERVER=$KORE_RPC_BOOSTER ./runDirectoryTest.sh test-$name --time
+              elif [ "$name" = "vacuous" ]; then
+                  SERVER=$KORE_RPC_DEV ./runDirectoryTest.sh test-$name
+                  SERVER=$KORE_RPC_BOOSTER ./runDirectoryTest.sh test-$name
               elif [ "$name" = "substitutions" ]; then
                   SERVER=$KORE_RPC_DEV ./runDirectoryTest.sh test-$name --time
                   SERVER=$KORE_RPC_BOOSTER ./runDirectoryTest.sh test-$name --time

--- a/test/rpc-integration/resources/vacuous.kore
+++ b/test/rpc-integration/resources/vacuous.kore
@@ -1,0 +1,1 @@
+diamond.kore

--- a/test/rpc-integration/test-vacuous/README.md
+++ b/test/rpc-integration/test-vacuous/README.md
@@ -1,0 +1,53 @@
+# Tests for `kore-rpc-booster` returning vacuous results after simplification
+
+Since `kore-rpc-booster` does not consider combinations of constraints, it won't discover when a reached state (or the initial state) simplifies to `\bottom`. In such cases, the `execute` request should return the current state with `"reason": "vacuous"` in the result.
+
+The `diamond/test.k` semantics is used, which consists of simple state
+transition rules featuring additional constraints on a variable
+`X:Int` in the configuration.
+
+Rules `init` and `AC` introduce constraints on this variable:
+
+* Rule `init => a` ensures `X ==Int 42`
+* Rule `a => c` ensures `X =/=Int 42`
+
+1) _vacuous-at-branch_
+
+   _Input:_
+   `execute` request with initial state `<k>init</k><int>0</int>`
+
+   _Expected:_
+   - Rewrite with `init` rule creates a false constraint `0 ==Int 42`
+     because `X ==Int 0` initially.
+   - The rewrite proceeds to the branch (`a => b` or `a => c`)
+   - Both branches are discarded because of the contradiction, the
+     result is `vacuous` with state `a`.
+
+   With `kore-rpc-dev`, the term won't be rewritten because the contradiction
+   will be recognised during the rewrite (simplification after each step).
+
+1) _vacuous-var-at-branch_ Same as 1) but using a variable `N` for the
+   `int` field and a constraint `N ==Int 0`.
+
+1) _vacuous-without-rewrite_
+
+   _Input:_
+   - `execute` request with initial state  `<k>d</k><int>N</int> \and N
+     ==Int 1  \and N =/=Int  1` (A contradiction in the initial constraints).
+
+   _Expected:_
+   - The rewrite is stuck with `<k>d</k><int>N</int> \and...(contradiction)`
+   - The result is simplified and discovered to be `vacuous` (with state `d`).
+1) _vacuous-but-rewritten_
+
+   _Input:_
+   - `execute` request with initial state  `<k>b</k><int>N</int> \and N
+     ==Int 1  \and N =/=Int  1` (A contradiction in the initial constraints).
+
+   _Expected:_
+   - Rewrite with `BD` (despite the contradiction)
+   - The rewrite is stuck with `<k>d</k><int>N</int> \and...(contradiction)`
+   - The result is simplified and discovered to be `vacuous` (with state `d`).
+
+With `kore-rpc-dev`, some contradictions will be discovered before or while
+attempting to rewrite (at the time of writing, it returns `stuck`, though).

--- a/test/rpc-integration/test-vacuous/response-vacuous-at-branch.json
+++ b/test/rpc-integration/test-vacuous/response-vacuous-at-branch.json
@@ -1,0 +1,151 @@
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+        "reason": "vacuous",
+        "depth": 1,
+        "state": {
+            "term": {
+                "format": "KORE",
+                "version": 1,
+                "term": {
+                    "tag": "App",
+                    "name": "Lbl'-LT-'generatedTop'-GT-'",
+                    "sorts": [],
+                    "args": [
+                        {
+                            "tag": "App",
+                            "name": "Lbl'-LT-'k'-GT-'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "App",
+                                    "name": "kseq",
+                                    "sorts": [],
+                                    "args": [
+                                        {
+                                            "tag": "App",
+                                            "name": "inj",
+                                            "sorts": [
+                                                {
+                                                    "tag": "SortApp",
+                                                    "name": "SortState",
+                                                    "args": []
+                                                },
+                                                {
+                                                    "tag": "SortApp",
+                                                    "name": "SortKItem",
+                                                    "args": []
+                                                }
+                                            ],
+                                            "args": [
+                                                {
+                                                    "tag": "DV",
+                                                    "sort": {
+                                                        "tag": "SortApp",
+                                                        "name": "SortState",
+                                                        "args": []
+                                                    },
+                                                    "value": "a"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "tag": "App",
+                                            "name": "dotk",
+                                            "sorts": [],
+                                            "args": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "tag": "App",
+                            "name": "Lbl'-LT-'int'-GT-'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "DV",
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortInt",
+                                        "args": []
+                                    },
+                                    "value": "0"
+                                }
+                            ]
+                        },
+                        {
+                            "tag": "App",
+                            "name": "Lbl'-LT-'generatedCounter'-GT-'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "DV",
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortInt",
+                                        "args": []
+                                    },
+                                    "value": "0"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            "predicate": {
+                "format": "KORE",
+                "version": 1,
+                "term": {
+                    "tag": "Equals",
+                    "argSort": {
+                        "tag": "SortApp",
+                        "name": "SortBool",
+                        "args": []
+                    },
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortGeneratedTopCell",
+                        "args": []
+                    },
+                    "first": {
+                        "tag": "App",
+                        "name": "Lbl'UndsEqlsEqls'Int'Unds'",
+                        "sorts": [],
+                        "args": [
+                            {
+                                "tag": "DV",
+                                "sort": {
+                                    "tag": "SortApp",
+                                    "name": "SortInt",
+                                    "args": []
+                                },
+                                "value": "0"
+                            },
+                            {
+                                "tag": "DV",
+                                "sort": {
+                                    "tag": "SortApp",
+                                    "name": "SortInt",
+                                    "args": []
+                                },
+                                "value": "42"
+                            }
+                        ]
+                    },
+                    "second": {
+                        "tag": "DV",
+                        "sort": {
+                            "tag": "SortApp",
+                            "name": "SortBool",
+                            "args": []
+                        },
+                        "value": "true"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/rpc-integration/test-vacuous/response-vacuous-at-branch.kore-rpc-dev
+++ b/test/rpc-integration/test-vacuous/response-vacuous-at-branch.kore-rpc-dev
@@ -1,0 +1,100 @@
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+        "reason": "vacuous",
+        "depth": 0,
+        "state": {
+            "term": {
+                "format": "KORE",
+                "version": 1,
+                "term": {
+                    "tag": "App",
+                    "name": "Lbl'-LT-'generatedTop'-GT-'",
+                    "sorts": [],
+                    "args": [
+                        {
+                            "tag": "App",
+                            "name": "Lbl'-LT-'k'-GT-'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "App",
+                                    "name": "kseq",
+                                    "sorts": [],
+                                    "args": [
+                                        {
+                                            "tag": "App",
+                                            "name": "inj",
+                                            "sorts": [
+                                                {
+                                                    "tag": "SortApp",
+                                                    "name": "SortState",
+                                                    "args": []
+                                                },
+                                                {
+                                                    "tag": "SortApp",
+                                                    "name": "SortKItem",
+                                                    "args": []
+                                                }
+                                            ],
+                                            "args": [
+                                                {
+                                                    "tag": "DV",
+                                                    "sort": {
+                                                        "tag": "SortApp",
+                                                        "name": "SortState",
+                                                        "args": []
+                                                    },
+                                                    "value": "init"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "tag": "App",
+                                            "name": "dotk",
+                                            "sorts": [],
+                                            "args": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "tag": "App",
+                            "name": "Lbl'-LT-'int'-GT-'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "DV",
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortInt",
+                                        "args": []
+                                    },
+                                    "value": "0"
+                                }
+                            ]
+                        },
+                        {
+                            "tag": "App",
+                            "name": "Lbl'-LT-'generatedCounter'-GT-'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "DV",
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortInt",
+                                        "args": []
+                                    },
+                                    "value": "0"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/test/rpc-integration/test-vacuous/response-vacuous-but-rewritten.json
+++ b/test/rpc-integration/test-vacuous/response-vacuous-but-rewritten.json
@@ -1,0 +1,213 @@
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+        "reason": "vacuous",
+        "depth": 1,
+        "state": {
+            "term": {
+                "format": "KORE",
+                "version": 1,
+                "term": {
+                    "tag": "App",
+                    "name": "Lbl'-LT-'generatedTop'-GT-'",
+                    "sorts": [],
+                    "args": [
+                        {
+                            "tag": "App",
+                            "name": "Lbl'-LT-'k'-GT-'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "App",
+                                    "name": "kseq",
+                                    "sorts": [],
+                                    "args": [
+                                        {
+                                            "tag": "App",
+                                            "name": "inj",
+                                            "sorts": [
+                                                {
+                                                    "tag": "SortApp",
+                                                    "name": "SortState",
+                                                    "args": []
+                                                },
+                                                {
+                                                    "tag": "SortApp",
+                                                    "name": "SortKItem",
+                                                    "args": []
+                                                }
+                                            ],
+                                            "args": [
+                                                {
+                                                    "tag": "DV",
+                                                    "sort": {
+                                                        "tag": "SortApp",
+                                                        "name": "SortState",
+                                                        "args": []
+                                                    },
+                                                    "value": "d"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "tag": "App",
+                                            "name": "dotk",
+                                            "sorts": [],
+                                            "args": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "tag": "App",
+                            "name": "Lbl'-LT-'int'-GT-'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "EVar",
+                                    "name": "N",
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortInt",
+                                        "args": []
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "tag": "App",
+                            "name": "Lbl'-LT-'generatedCounter'-GT-'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "DV",
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortInt",
+                                        "args": []
+                                    },
+                                    "value": "0"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            "predicate": {
+                "format": "KORE",
+                "version": 1,
+                "term": {
+                    "tag": "And",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortGeneratedTopCell",
+                        "args": []
+                    },
+                    "first": {
+                        "tag": "Equals",
+                        "argSort": {
+                            "tag": "SortApp",
+                            "name": "SortBool",
+                            "args": []
+                        },
+                        "sort": {
+                            "tag": "SortApp",
+                            "name": "SortGeneratedTopCell",
+                            "args": []
+                        },
+                        "first": {
+                            "tag": "App",
+                            "name": "Lbl'UndsEqlsEqls'Int'Unds'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "EVar",
+                                    "name": "N",
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortInt",
+                                        "args": []
+                                    }
+                                },
+                                {
+                                    "tag": "DV",
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortInt",
+                                        "args": []
+                                    },
+                                    "value": "0"
+                                }
+                            ]
+                        },
+                        "second": {
+                            "tag": "DV",
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortBool",
+                                "args": []
+                            },
+                            "value": "true"
+                        }
+                    },
+                    "second": {
+                        "tag": "Equals",
+                        "argSort": {
+                            "tag": "SortApp",
+                            "name": "SortBool",
+                            "args": []
+                        },
+                        "sort": {
+                            "tag": "SortApp",
+                            "name": "SortGeneratedTopCell",
+                            "args": []
+                        },
+                        "first": {
+                            "tag": "App",
+                            "name": "LblnotBool'Unds'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "App",
+                                    "name": "Lbl'UndsEqlsEqls'Int'Unds'",
+                                    "sorts": [],
+                                    "args": [
+                                        {
+                                            "tag": "EVar",
+                                            "name": "N",
+                                            "sort": {
+                                                "tag": "SortApp",
+                                                "name": "SortInt",
+                                                "args": []
+                                            }
+                                        },
+                                        {
+                                            "tag": "DV",
+                                            "sort": {
+                                                "tag": "SortApp",
+                                                "name": "SortInt",
+                                                "args": []
+                                            },
+                                            "value": "0"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "second": {
+                            "tag": "DV",
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortBool",
+                                "args": []
+                            },
+                            "value": "true"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/rpc-integration/test-vacuous/response-vacuous-but-rewritten.kore-rpc-dev
+++ b/test/rpc-integration/test-vacuous/response-vacuous-but-rewritten.kore-rpc-dev
@@ -1,0 +1,210 @@
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+        "reason": "stuck",
+        "depth": 0,
+        "state": {
+            "term": {
+                "format": "KORE",
+                "version": 1,
+                "term": {
+                    "tag": "And",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortGeneratedTopCell",
+                        "args": []
+                    },
+                    "first": {
+                        "tag": "App",
+                        "name": "Lbl'-LT-'generatedTop'-GT-'",
+                        "sorts": [],
+                        "args": [
+                            {
+                                "tag": "App",
+                                "name": "Lbl'-LT-'k'-GT-'",
+                                "sorts": [],
+                                "args": [
+                                    {
+                                        "tag": "App",
+                                        "name": "kseq",
+                                        "sorts": [],
+                                        "args": [
+                                            {
+                                                "tag": "App",
+                                                "name": "inj",
+                                                "sorts": [
+                                                    {
+                                                        "tag": "SortApp",
+                                                        "name": "SortState",
+                                                        "args": []
+                                                    },
+                                                    {
+                                                        "tag": "SortApp",
+                                                        "name": "SortKItem",
+                                                        "args": []
+                                                    }
+                                                ],
+                                                "args": [
+                                                    {
+                                                        "tag": "DV",
+                                                        "sort": {
+                                                            "tag": "SortApp",
+                                                            "name": "SortState",
+                                                            "args": []
+                                                        },
+                                                        "value": "b"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "tag": "App",
+                                                "name": "dotk",
+                                                "sorts": [],
+                                                "args": []
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "tag": "App",
+                                "name": "Lbl'-LT-'int'-GT-'",
+                                "sorts": [],
+                                "args": [
+                                    {
+                                        "tag": "EVar",
+                                        "name": "N",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortInt",
+                                            "args": []
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "tag": "App",
+                                "name": "Lbl'-LT-'generatedCounter'-GT-'",
+                                "sorts": [],
+                                "args": [
+                                    {
+                                        "tag": "DV",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortInt",
+                                            "args": []
+                                        },
+                                        "value": "0"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "second": {
+                        "tag": "And",
+                        "sort": {
+                            "tag": "SortApp",
+                            "name": "SortGeneratedTopCell",
+                            "args": []
+                        },
+                        "first": {
+                            "tag": "Equals",
+                            "argSort": {
+                                "tag": "SortApp",
+                                "name": "SortBool",
+                                "args": []
+                            },
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortGeneratedTopCell",
+                                "args": []
+                            },
+                            "first": {
+                                "tag": "App",
+                                "name": "Lbl'UndsEqlsEqls'Int'Unds'",
+                                "sorts": [],
+                                "args": [
+                                    {
+                                        "tag": "EVar",
+                                        "name": "N",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortInt",
+                                            "args": []
+                                        }
+                                    },
+                                    {
+                                        "tag": "DV",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortInt",
+                                            "args": []
+                                        },
+                                        "value": "0"
+                                    }
+                                ]
+                            },
+                            "second": {
+                                "tag": "DV",
+                                "sort": {
+                                    "tag": "SortApp",
+                                    "name": "SortBool",
+                                    "args": []
+                                },
+                                "value": "true"
+                            }
+                        },
+                        "second": {
+                            "tag": "Equals",
+                            "argSort": {
+                                "tag": "SortApp",
+                                "name": "SortBool",
+                                "args": []
+                            },
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortGeneratedTopCell",
+                                "args": []
+                            },
+                            "first": {
+                                "tag": "App",
+                                "name": "Lbl'UndsEqlsSlshEqls'Int'Unds'",
+                                "sorts": [],
+                                "args": [
+                                    {
+                                        "tag": "EVar",
+                                        "name": "N",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortInt",
+                                            "args": []
+                                        }
+                                    },
+                                    {
+                                        "tag": "DV",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortInt",
+                                            "args": []
+                                        },
+                                        "value": "0"
+                                    }
+                                ]
+                            },
+                            "second": {
+                                "tag": "DV",
+                                "sort": {
+                                    "tag": "SortApp",
+                                    "name": "SortBool",
+                                    "args": []
+                                },
+                                "value": "true"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/rpc-integration/test-vacuous/response-vacuous-var-at-branch.json
+++ b/test/rpc-integration/test-vacuous/response-vacuous-var-at-branch.json
@@ -1,0 +1,206 @@
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+        "reason": "vacuous",
+        "depth": 1,
+        "state": {
+            "term": {
+                "format": "KORE",
+                "version": 1,
+                "term": {
+                    "tag": "App",
+                    "name": "Lbl'-LT-'generatedTop'-GT-'",
+                    "sorts": [],
+                    "args": [
+                        {
+                            "tag": "App",
+                            "name": "Lbl'-LT-'k'-GT-'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "App",
+                                    "name": "kseq",
+                                    "sorts": [],
+                                    "args": [
+                                        {
+                                            "tag": "App",
+                                            "name": "inj",
+                                            "sorts": [
+                                                {
+                                                    "tag": "SortApp",
+                                                    "name": "SortState",
+                                                    "args": []
+                                                },
+                                                {
+                                                    "tag": "SortApp",
+                                                    "name": "SortKItem",
+                                                    "args": []
+                                                }
+                                            ],
+                                            "args": [
+                                                {
+                                                    "tag": "DV",
+                                                    "sort": {
+                                                        "tag": "SortApp",
+                                                        "name": "SortState",
+                                                        "args": []
+                                                    },
+                                                    "value": "a"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "tag": "App",
+                                            "name": "dotk",
+                                            "sorts": [],
+                                            "args": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "tag": "App",
+                            "name": "Lbl'-LT-'int'-GT-'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "EVar",
+                                    "name": "N",
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortInt",
+                                        "args": []
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "tag": "App",
+                            "name": "Lbl'-LT-'generatedCounter'-GT-'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "DV",
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortInt",
+                                        "args": []
+                                    },
+                                    "value": "0"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            "predicate": {
+                "format": "KORE",
+                "version": 1,
+                "term": {
+                    "tag": "And",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortGeneratedTopCell",
+                        "args": []
+                    },
+                    "first": {
+                        "tag": "Equals",
+                        "argSort": {
+                            "tag": "SortApp",
+                            "name": "SortBool",
+                            "args": []
+                        },
+                        "sort": {
+                            "tag": "SortApp",
+                            "name": "SortGeneratedTopCell",
+                            "args": []
+                        },
+                        "first": {
+                            "tag": "App",
+                            "name": "Lbl'UndsEqlsEqls'Int'Unds'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "EVar",
+                                    "name": "N",
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortInt",
+                                        "args": []
+                                    }
+                                },
+                                {
+                                    "tag": "DV",
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortInt",
+                                        "args": []
+                                    },
+                                    "value": "42"
+                                }
+                            ]
+                        },
+                        "second": {
+                            "tag": "DV",
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortBool",
+                                "args": []
+                            },
+                            "value": "true"
+                        }
+                    },
+                    "second": {
+                        "tag": "Equals",
+                        "argSort": {
+                            "tag": "SortApp",
+                            "name": "SortBool",
+                            "args": []
+                        },
+                        "sort": {
+                            "tag": "SortApp",
+                            "name": "SortGeneratedTopCell",
+                            "args": []
+                        },
+                        "first": {
+                            "tag": "App",
+                            "name": "Lbl'UndsEqlsEqls'Int'Unds'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "EVar",
+                                    "name": "N",
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortInt",
+                                        "args": []
+                                    }
+                                },
+                                {
+                                    "tag": "DV",
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortInt",
+                                        "args": []
+                                    },
+                                    "value": "0"
+                                }
+                            ]
+                        },
+                        "second": {
+                            "tag": "DV",
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortBool",
+                                "args": []
+                            },
+                            "value": "true"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/rpc-integration/test-vacuous/response-vacuous-var-at-branch.kore-rpc-dev
+++ b/test/rpc-integration/test-vacuous/response-vacuous-var-at-branch.kore-rpc-dev
@@ -1,0 +1,155 @@
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+        "reason": "vacuous",
+        "depth": 0,
+        "state": {
+            "term": {
+                "format": "KORE",
+                "version": 1,
+                "term": {
+                    "tag": "And",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortGeneratedTopCell",
+                        "args": []
+                    },
+                    "first": {
+                        "tag": "App",
+                        "name": "Lbl'-LT-'generatedTop'-GT-'",
+                        "sorts": [],
+                        "args": [
+                            {
+                                "tag": "App",
+                                "name": "Lbl'-LT-'k'-GT-'",
+                                "sorts": [],
+                                "args": [
+                                    {
+                                        "tag": "App",
+                                        "name": "kseq",
+                                        "sorts": [],
+                                        "args": [
+                                            {
+                                                "tag": "App",
+                                                "name": "inj",
+                                                "sorts": [
+                                                    {
+                                                        "tag": "SortApp",
+                                                        "name": "SortState",
+                                                        "args": []
+                                                    },
+                                                    {
+                                                        "tag": "SortApp",
+                                                        "name": "SortKItem",
+                                                        "args": []
+                                                    }
+                                                ],
+                                                "args": [
+                                                    {
+                                                        "tag": "DV",
+                                                        "sort": {
+                                                            "tag": "SortApp",
+                                                            "name": "SortState",
+                                                            "args": []
+                                                        },
+                                                        "value": "init"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "tag": "App",
+                                                "name": "dotk",
+                                                "sorts": [],
+                                                "args": []
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "tag": "App",
+                                "name": "Lbl'-LT-'int'-GT-'",
+                                "sorts": [],
+                                "args": [
+                                    {
+                                        "tag": "EVar",
+                                        "name": "N",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortInt",
+                                            "args": []
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "tag": "App",
+                                "name": "Lbl'-LT-'generatedCounter'-GT-'",
+                                "sorts": [],
+                                "args": [
+                                    {
+                                        "tag": "DV",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortInt",
+                                            "args": []
+                                        },
+                                        "value": "0"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "second": {
+                        "tag": "Equals",
+                        "argSort": {
+                            "tag": "SortApp",
+                            "name": "SortBool",
+                            "args": []
+                        },
+                        "sort": {
+                            "tag": "SortApp",
+                            "name": "SortGeneratedTopCell",
+                            "args": []
+                        },
+                        "first": {
+                            "tag": "App",
+                            "name": "Lbl'UndsEqlsEqls'Int'Unds'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "EVar",
+                                    "name": "N",
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortInt",
+                                        "args": []
+                                    }
+                                },
+                                {
+                                    "tag": "DV",
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortInt",
+                                        "args": []
+                                    },
+                                    "value": "0"
+                                }
+                            ]
+                        },
+                        "second": {
+                            "tag": "DV",
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortBool",
+                                "args": []
+                            },
+                            "value": "true"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/rpc-integration/test-vacuous/response-vacuous-without-rewrite.json
+++ b/test/rpc-integration/test-vacuous/response-vacuous-without-rewrite.json
@@ -1,0 +1,213 @@
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+        "reason": "vacuous",
+        "depth": 0,
+        "state": {
+            "term": {
+                "format": "KORE",
+                "version": 1,
+                "term": {
+                    "tag": "App",
+                    "name": "Lbl'-LT-'generatedTop'-GT-'",
+                    "sorts": [],
+                    "args": [
+                        {
+                            "tag": "App",
+                            "name": "Lbl'-LT-'k'-GT-'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "App",
+                                    "name": "kseq",
+                                    "sorts": [],
+                                    "args": [
+                                        {
+                                            "tag": "App",
+                                            "name": "inj",
+                                            "sorts": [
+                                                {
+                                                    "tag": "SortApp",
+                                                    "name": "SortState",
+                                                    "args": []
+                                                },
+                                                {
+                                                    "tag": "SortApp",
+                                                    "name": "SortKItem",
+                                                    "args": []
+                                                }
+                                            ],
+                                            "args": [
+                                                {
+                                                    "tag": "DV",
+                                                    "sort": {
+                                                        "tag": "SortApp",
+                                                        "name": "SortState",
+                                                        "args": []
+                                                    },
+                                                    "value": "d"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "tag": "App",
+                                            "name": "dotk",
+                                            "sorts": [],
+                                            "args": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "tag": "App",
+                            "name": "Lbl'-LT-'int'-GT-'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "EVar",
+                                    "name": "N",
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortInt",
+                                        "args": []
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "tag": "App",
+                            "name": "Lbl'-LT-'generatedCounter'-GT-'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "DV",
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortInt",
+                                        "args": []
+                                    },
+                                    "value": "0"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            "predicate": {
+                "format": "KORE",
+                "version": 1,
+                "term": {
+                    "tag": "And",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortGeneratedTopCell",
+                        "args": []
+                    },
+                    "first": {
+                        "tag": "Equals",
+                        "argSort": {
+                            "tag": "SortApp",
+                            "name": "SortBool",
+                            "args": []
+                        },
+                        "sort": {
+                            "tag": "SortApp",
+                            "name": "SortGeneratedTopCell",
+                            "args": []
+                        },
+                        "first": {
+                            "tag": "App",
+                            "name": "Lbl'UndsEqlsEqls'Int'Unds'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "EVar",
+                                    "name": "N",
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortInt",
+                                        "args": []
+                                    }
+                                },
+                                {
+                                    "tag": "DV",
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortInt",
+                                        "args": []
+                                    },
+                                    "value": "0"
+                                }
+                            ]
+                        },
+                        "second": {
+                            "tag": "DV",
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortBool",
+                                "args": []
+                            },
+                            "value": "true"
+                        }
+                    },
+                    "second": {
+                        "tag": "Equals",
+                        "argSort": {
+                            "tag": "SortApp",
+                            "name": "SortBool",
+                            "args": []
+                        },
+                        "sort": {
+                            "tag": "SortApp",
+                            "name": "SortGeneratedTopCell",
+                            "args": []
+                        },
+                        "first": {
+                            "tag": "App",
+                            "name": "LblnotBool'Unds'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "App",
+                                    "name": "Lbl'UndsEqlsEqls'Int'Unds'",
+                                    "sorts": [],
+                                    "args": [
+                                        {
+                                            "tag": "EVar",
+                                            "name": "N",
+                                            "sort": {
+                                                "tag": "SortApp",
+                                                "name": "SortInt",
+                                                "args": []
+                                            }
+                                        },
+                                        {
+                                            "tag": "DV",
+                                            "sort": {
+                                                "tag": "SortApp",
+                                                "name": "SortInt",
+                                                "args": []
+                                            },
+                                            "value": "0"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "second": {
+                            "tag": "DV",
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortBool",
+                                "args": []
+                            },
+                            "value": "true"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/rpc-integration/test-vacuous/response-vacuous-without-rewrite.kore-rpc-dev
+++ b/test/rpc-integration/test-vacuous/response-vacuous-without-rewrite.kore-rpc-dev
@@ -1,0 +1,210 @@
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+        "reason": "stuck",
+        "depth": 0,
+        "state": {
+            "term": {
+                "format": "KORE",
+                "version": 1,
+                "term": {
+                    "tag": "And",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortGeneratedTopCell",
+                        "args": []
+                    },
+                    "first": {
+                        "tag": "App",
+                        "name": "Lbl'-LT-'generatedTop'-GT-'",
+                        "sorts": [],
+                        "args": [
+                            {
+                                "tag": "App",
+                                "name": "Lbl'-LT-'k'-GT-'",
+                                "sorts": [],
+                                "args": [
+                                    {
+                                        "tag": "App",
+                                        "name": "kseq",
+                                        "sorts": [],
+                                        "args": [
+                                            {
+                                                "tag": "App",
+                                                "name": "inj",
+                                                "sorts": [
+                                                    {
+                                                        "tag": "SortApp",
+                                                        "name": "SortState",
+                                                        "args": []
+                                                    },
+                                                    {
+                                                        "tag": "SortApp",
+                                                        "name": "SortKItem",
+                                                        "args": []
+                                                    }
+                                                ],
+                                                "args": [
+                                                    {
+                                                        "tag": "DV",
+                                                        "sort": {
+                                                            "tag": "SortApp",
+                                                            "name": "SortState",
+                                                            "args": []
+                                                        },
+                                                        "value": "d"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "tag": "App",
+                                                "name": "dotk",
+                                                "sorts": [],
+                                                "args": []
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "tag": "App",
+                                "name": "Lbl'-LT-'int'-GT-'",
+                                "sorts": [],
+                                "args": [
+                                    {
+                                        "tag": "EVar",
+                                        "name": "N",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortInt",
+                                            "args": []
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "tag": "App",
+                                "name": "Lbl'-LT-'generatedCounter'-GT-'",
+                                "sorts": [],
+                                "args": [
+                                    {
+                                        "tag": "DV",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortInt",
+                                            "args": []
+                                        },
+                                        "value": "0"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "second": {
+                        "tag": "And",
+                        "sort": {
+                            "tag": "SortApp",
+                            "name": "SortGeneratedTopCell",
+                            "args": []
+                        },
+                        "first": {
+                            "tag": "Equals",
+                            "argSort": {
+                                "tag": "SortApp",
+                                "name": "SortBool",
+                                "args": []
+                            },
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortGeneratedTopCell",
+                                "args": []
+                            },
+                            "first": {
+                                "tag": "App",
+                                "name": "Lbl'UndsEqlsEqls'Int'Unds'",
+                                "sorts": [],
+                                "args": [
+                                    {
+                                        "tag": "EVar",
+                                        "name": "N",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortInt",
+                                            "args": []
+                                        }
+                                    },
+                                    {
+                                        "tag": "DV",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortInt",
+                                            "args": []
+                                        },
+                                        "value": "0"
+                                    }
+                                ]
+                            },
+                            "second": {
+                                "tag": "DV",
+                                "sort": {
+                                    "tag": "SortApp",
+                                    "name": "SortBool",
+                                    "args": []
+                                },
+                                "value": "true"
+                            }
+                        },
+                        "second": {
+                            "tag": "Equals",
+                            "argSort": {
+                                "tag": "SortApp",
+                                "name": "SortBool",
+                                "args": []
+                            },
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortGeneratedTopCell",
+                                "args": []
+                            },
+                            "first": {
+                                "tag": "App",
+                                "name": "Lbl'UndsEqlsSlshEqls'Int'Unds'",
+                                "sorts": [],
+                                "args": [
+                                    {
+                                        "tag": "EVar",
+                                        "name": "N",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortInt",
+                                            "args": []
+                                        }
+                                    },
+                                    {
+                                        "tag": "DV",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortInt",
+                                            "args": []
+                                        },
+                                        "value": "0"
+                                    }
+                                ]
+                            },
+                            "second": {
+                                "tag": "DV",
+                                "sort": {
+                                    "tag": "SortApp",
+                                    "name": "SortBool",
+                                    "args": []
+                                },
+                                "value": "true"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/rpc-integration/test-vacuous/state-vacuous-at-branch.execute
+++ b/test/rpc-integration/test-vacuous/state-vacuous-at-branch.execute
@@ -1,0 +1,90 @@
+{
+  "format": "KORE",
+  "version": 1,
+  "term": {
+    "tag": "App",
+    "name": "Lbl'-LT-'generatedTop'-GT-'",
+    "sorts": [],
+    "args": [
+      {
+        "tag": "App",
+        "name": "Lbl'-LT-'k'-GT-'",
+        "sorts": [],
+        "args": [
+          {
+            "tag": "App",
+            "name": "kseq",
+            "sorts": [],
+            "args": [
+              {
+                "tag": "App",
+                "name": "inj",
+                "sorts": [
+                  {
+                    "tag": "SortApp",
+                    "name": "SortState",
+                    "args": []
+                  },
+                  {
+                    "tag": "SortApp",
+                    "name": "SortKItem",
+                    "args": []
+                  }
+                ],
+                "args": [
+                  {
+                    "tag": "DV",
+                    "sort": {
+                      "tag": "SortApp",
+                      "name": "SortState",
+                      "args": []
+                    },
+                    "value": "init"
+                  }
+                ]
+              },
+              {
+                "tag": "App",
+                "name": "dotk",
+                "sorts": [],
+                "args": []
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "tag": "App",
+        "name": "Lbl'-LT-'int'-GT-'",
+        "sorts": [],
+        "args": [
+          {
+            "tag": "DV",
+            "sort": {
+              "tag": "SortApp",
+              "name": "SortInt",
+              "args": []
+            },
+            "value": "0"
+          }
+        ]
+      },
+      {
+        "tag": "App",
+        "name": "Lbl'-LT-'generatedCounter'-GT-'",
+        "sorts": [],
+        "args": [
+          {
+            "tag": "DV",
+            "sort": {
+              "tag": "SortApp",
+              "name": "SortInt",
+              "args": []
+            },
+            "value": "0"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/rpc-integration/test-vacuous/state-vacuous-but-rewritten.execute
+++ b/test/rpc-integration/test-vacuous/state-vacuous-but-rewritten.execute
@@ -1,0 +1,200 @@
+{
+  "format": "KORE",
+  "version": 1,
+  "term": {
+    "tag": "And",
+    "sort": {
+      "tag": "SortApp",
+      "name": "SortGeneratedTopCell",
+      "args": []
+    },
+    "first": {
+      "tag": "App",
+      "name": "Lbl'-LT-'generatedTop'-GT-'",
+      "sorts": [],
+      "args": [
+        {
+          "tag": "App",
+          "name": "Lbl'-LT-'k'-GT-'",
+          "sorts": [],
+          "args": [
+            {
+              "tag": "App",
+              "name": "kseq",
+              "sorts": [],
+              "args": [
+                {
+                  "tag": "App",
+                  "name": "inj",
+                  "sorts": [
+                    {
+                      "tag": "SortApp",
+                      "name": "SortState",
+                      "args": []
+                    },
+                    {
+                      "tag": "SortApp",
+                      "name": "SortKItem",
+                      "args": []
+                    }
+                  ],
+                  "args": [
+                    {
+                      "tag": "DV",
+                      "sort": {
+                        "tag": "SortApp",
+                        "name": "SortState",
+                        "args": []
+                      },
+                      "value": "b"
+                    }
+                  ]
+                },
+                {
+                  "tag": "App",
+                  "name": "dotk",
+                  "sorts": [],
+                  "args": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "tag": "App",
+          "name": "Lbl'-LT-'int'-GT-'",
+          "sorts": [],
+          "args": [
+            {
+              "tag": "EVar",
+              "name": "N",
+              "sort": {
+                "tag": "SortApp",
+                "name": "SortInt",
+                "args": []
+              }
+            }
+          ]
+        },
+        {
+          "tag": "App",
+          "name": "Lbl'-LT-'generatedCounter'-GT-'",
+          "sorts": [],
+          "args": [
+            {
+              "tag": "DV",
+              "sort": {
+                "tag": "SortApp",
+                "name": "SortInt",
+                "args": []
+              },
+              "value": "0"
+            }
+          ]
+        }
+      ]
+    },
+    "second": {
+      "tag": "And",
+      "sort": {
+        "tag": "SortApp",
+        "name": "SortGeneratedTopCell",
+        "args": []
+      },
+      "first": {
+        "tag": "Equals",
+        "sort": {
+          "tag": "SortApp",
+          "name": "SortGeneratedTopCell",
+          "args": []
+        },
+        "argSort": {
+          "tag": "SortApp",
+          "name": "SortBool",
+          "args": []
+        },
+        "first": {
+          "tag": "App",
+          "name": "Lbl'UndsEqlsEqls'Int'Unds'",
+          "sorts": [],
+          "args": [
+            {
+              "tag": "EVar",
+              "name": "N",
+              "sort": {
+                "tag": "SortApp",
+                "name": "SortInt",
+                "args": []
+              }
+            },
+            {
+              "tag": "DV",
+              "sort": {
+                "tag": "SortApp",
+                "name": "SortInt",
+                "args": []
+              },
+              "value": "0"
+            }
+          ]
+        },
+        "second": {
+          "tag": "DV",
+          "sort": {
+            "tag": "SortApp",
+            "name": "SortBool",
+            "args": []
+          },
+          "value": "true"
+        }
+      },
+      "second": {
+        "tag": "Equals",
+        "sort": {
+          "tag": "SortApp",
+          "name": "SortGeneratedTopCell",
+          "args": []
+        },
+        "argSort": {
+          "tag": "SortApp",
+          "name": "SortBool",
+          "args": []
+        },
+        "first": {
+          "tag": "App",
+          "name": "Lbl'UndsEqlsSlshEqls'Int'Unds'",
+          "sorts": [],
+          "args": [
+            {
+              "tag": "EVar",
+              "name": "N",
+              "sort": {
+                "tag": "SortApp",
+                "name": "SortInt",
+                "args": []
+              }
+            },
+            {
+              "tag": "DV",
+              "sort": {
+                "tag": "SortApp",
+                "name": "SortInt",
+                "args": []
+              },
+              "value": "0"
+            }
+          ]
+        },
+        "second": {
+          "tag": "DV",
+          "sort": {
+            "tag": "SortApp",
+            "name": "SortBool",
+            "args": []
+          },
+          "value": "true"
+        }
+      }
+    }
+  }
+}

--- a/test/rpc-integration/test-vacuous/state-vacuous-var-at-branch.execute
+++ b/test/rpc-integration/test-vacuous/state-vacuous-var-at-branch.execute
@@ -1,0 +1,145 @@
+{
+  "format": "KORE",
+  "version": 1,
+  "term": {
+    "tag": "And",
+    "sort": {
+      "tag": "SortApp",
+      "name": "SortGeneratedTopCell",
+      "args": []
+    },
+    "first": {
+      "tag": "App",
+      "name": "Lbl'-LT-'generatedTop'-GT-'",
+      "sorts": [],
+      "args": [
+        {
+          "tag": "App",
+          "name": "Lbl'-LT-'k'-GT-'",
+          "sorts": [],
+          "args": [
+            {
+              "tag": "App",
+              "name": "kseq",
+              "sorts": [],
+              "args": [
+                {
+                  "tag": "App",
+                  "name": "inj",
+                  "sorts": [
+                    {
+                      "tag": "SortApp",
+                      "name": "SortState",
+                      "args": []
+                    },
+                    {
+                      "tag": "SortApp",
+                      "name": "SortKItem",
+                      "args": []
+                    }
+                  ],
+                  "args": [
+                    {
+                      "tag": "DV",
+                      "sort": {
+                        "tag": "SortApp",
+                        "name": "SortState",
+                        "args": []
+                      },
+                      "value": "init"
+                    }
+                  ]
+                },
+                {
+                  "tag": "App",
+                  "name": "dotk",
+                  "sorts": [],
+                  "args": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "tag": "App",
+          "name": "Lbl'-LT-'int'-GT-'",
+          "sorts": [],
+          "args": [
+            {
+              "tag": "EVar",
+              "name": "N",
+              "sort": {
+                "tag": "SortApp",
+                "name": "SortInt",
+                "args": []
+              }
+            }
+          ]
+        },
+        {
+          "tag": "App",
+          "name": "Lbl'-LT-'generatedCounter'-GT-'",
+          "sorts": [],
+          "args": [
+            {
+              "tag": "DV",
+              "sort": {
+                "tag": "SortApp",
+                "name": "SortInt",
+                "args": []
+              },
+              "value": "0"
+            }
+          ]
+        }
+      ]
+    },
+    "second": {
+      "tag": "Equals",
+      "sort": {
+        "tag": "SortApp",
+        "name": "SortGeneratedTopCell",
+        "args": []
+      },
+      "argSort": {
+        "tag": "SortApp",
+        "name": "SortBool",
+        "args": []
+      },
+      "first": {
+        "tag": "App",
+        "name": "Lbl'UndsEqlsEqls'Int'Unds'",
+        "sorts": [],
+        "args": [
+          {
+            "tag": "EVar",
+            "name": "N",
+            "sort": {
+              "tag": "SortApp",
+              "name": "SortInt",
+              "args": []
+            }
+          },
+          {
+            "tag": "DV",
+            "sort": {
+              "tag": "SortApp",
+              "name": "SortInt",
+              "args": []
+            },
+            "value": "0"
+          }
+        ]
+      },
+      "second": {
+        "tag": "DV",
+        "sort": {
+          "tag": "SortApp",
+          "name": "SortBool",
+          "args": []
+        },
+        "value": "true"
+      }
+    }
+  }
+}

--- a/test/rpc-integration/test-vacuous/state-vacuous-without-rewrite.execute
+++ b/test/rpc-integration/test-vacuous/state-vacuous-without-rewrite.execute
@@ -1,0 +1,200 @@
+{
+  "format": "KORE",
+  "version": 1,
+  "term": {
+    "tag": "And",
+    "sort": {
+      "tag": "SortApp",
+      "name": "SortGeneratedTopCell",
+      "args": []
+    },
+    "first": {
+      "tag": "App",
+      "name": "Lbl'-LT-'generatedTop'-GT-'",
+      "sorts": [],
+      "args": [
+        {
+          "tag": "App",
+          "name": "Lbl'-LT-'k'-GT-'",
+          "sorts": [],
+          "args": [
+            {
+              "tag": "App",
+              "name": "kseq",
+              "sorts": [],
+              "args": [
+                {
+                  "tag": "App",
+                  "name": "inj",
+                  "sorts": [
+                    {
+                      "tag": "SortApp",
+                      "name": "SortState",
+                      "args": []
+                    },
+                    {
+                      "tag": "SortApp",
+                      "name": "SortKItem",
+                      "args": []
+                    }
+                  ],
+                  "args": [
+                    {
+                      "tag": "DV",
+                      "sort": {
+                        "tag": "SortApp",
+                        "name": "SortState",
+                        "args": []
+                      },
+                      "value": "d"
+                    }
+                  ]
+                },
+                {
+                  "tag": "App",
+                  "name": "dotk",
+                  "sorts": [],
+                  "args": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "tag": "App",
+          "name": "Lbl'-LT-'int'-GT-'",
+          "sorts": [],
+          "args": [
+            {
+              "tag": "EVar",
+              "name": "N",
+              "sort": {
+                "tag": "SortApp",
+                "name": "SortInt",
+                "args": []
+              }
+            }
+          ]
+        },
+        {
+          "tag": "App",
+          "name": "Lbl'-LT-'generatedCounter'-GT-'",
+          "sorts": [],
+          "args": [
+            {
+              "tag": "DV",
+              "sort": {
+                "tag": "SortApp",
+                "name": "SortInt",
+                "args": []
+              },
+              "value": "0"
+            }
+          ]
+        }
+      ]
+    },
+    "second": {
+      "tag": "And",
+      "sort": {
+        "tag": "SortApp",
+        "name": "SortGeneratedTopCell",
+        "args": []
+      },
+      "first": {
+        "tag": "Equals",
+        "sort": {
+          "tag": "SortApp",
+          "name": "SortGeneratedTopCell",
+          "args": []
+        },
+        "argSort": {
+          "tag": "SortApp",
+          "name": "SortBool",
+          "args": []
+        },
+        "first": {
+          "tag": "App",
+          "name": "Lbl'UndsEqlsEqls'Int'Unds'",
+          "sorts": [],
+          "args": [
+            {
+              "tag": "EVar",
+              "name": "N",
+              "sort": {
+                "tag": "SortApp",
+                "name": "SortInt",
+                "args": []
+              }
+            },
+            {
+              "tag": "DV",
+              "sort": {
+                "tag": "SortApp",
+                "name": "SortInt",
+                "args": []
+              },
+              "value": "0"
+            }
+          ]
+        },
+        "second": {
+          "tag": "DV",
+          "sort": {
+            "tag": "SortApp",
+            "name": "SortBool",
+            "args": []
+          },
+          "value": "true"
+        }
+      },
+      "second": {
+        "tag": "Equals",
+        "sort": {
+          "tag": "SortApp",
+          "name": "SortGeneratedTopCell",
+          "args": []
+        },
+        "argSort": {
+          "tag": "SortApp",
+          "name": "SortBool",
+          "args": []
+        },
+        "first": {
+          "tag": "App",
+          "name": "Lbl'UndsEqlsSlshEqls'Int'Unds'",
+          "sorts": [],
+          "args": [
+            {
+              "tag": "EVar",
+              "name": "N",
+              "sort": {
+                "tag": "SortApp",
+                "name": "SortInt",
+                "args": []
+              }
+            },
+            {
+              "tag": "DV",
+              "sort": {
+                "tag": "SortApp",
+                "name": "SortInt",
+                "args": []
+              },
+              "value": "0"
+            }
+          ]
+        },
+        "second": {
+          "tag": "DV",
+          "sort": {
+            "tag": "SortApp",
+            "name": "SortBool",
+            "args": []
+          },
+          "value": "true"
+        }
+      }
+    }
+  }
+}

--- a/tools/booster/Proxy.hs
+++ b/tools/booster/Proxy.hs
@@ -15,9 +15,11 @@ import Control.Concurrent.MVar qualified as MVar
 import Control.Monad (when)
 import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Logger qualified as Log
-import Data.Aeson (ToJSON (..))
+import Data.Aeson (ToJSON (..), encode)
 import Data.Aeson.KeyMap qualified as Aeson
 import Data.Aeson.Types (Value (..))
+import Data.Bifunctor (second)
+import Data.Either (partitionEithers)
 import Data.Maybe (catMaybes, isJust, isNothing)
 import Data.Text (Text)
 import Data.Text qualified as Text
@@ -179,65 +181,69 @@ respondEither mbStatsVar booster kore req = case req of
                         "Booster " <> show boosterResult.reason <> " at " <> show boosterResult.depth
                     -- simplify Booster's state with Kore's simplifier
                     Log.logInfoNS "proxy" . Text.pack $ "Simplifying booster state and falling back to Kore "
-                    (simplifiedBoosterState, boosterStateSimplificationLogs) <-
-                        simplifyExecuteState logSettings r._module boosterResult.state
-
-                    -- attempt to do one step in the old backend
-                    (kResult, kTime) <-
-                        withTime $
-                            kore
-                                ( Execute
-                                    r
-                                        { state = execStateToKoreJson simplifiedBoosterState
-                                        , maxDepth = Just $ Depth 1
-                                        }
-                                )
-                    when (isJust mbStatsVar) $
-                        Log.logInfoNS "proxy" . Text.pack $
-                            "Kore fall-back in " <> microsWithUnit kTime
-                    case kResult of
-                        Right (Execute koreResult)
-                            | koreResult.reason == DepthBound -> do
-                                -- if we made one step, add the number of
-                                -- steps we have taken to the counter and
-                                -- attempt with booster again
-                                when (koreResult.depth == 0) $ error "Expected kore-rpc to take at least one step"
-                                Log.logInfoNS "proxy" $
-                                    Text.pack $
-                                        "kore depth-bound, continuing... (currently at "
-                                            <> show (currentDepth + boosterResult.depth + koreResult.depth)
-                                            <> ")"
-                                let accumulatedLogs =
-                                        combineLogs
-                                            [ rpcLogs
-                                            , boosterResult.logs
-                                            , boosterStateSimplificationLogs
-                                            , koreResult.logs
-                                            ]
-                                executionLoop
-                                    logSettings
-                                    ( currentDepth + boosterResult.depth + koreResult.depth
-                                    , time + bTime + kTime
-                                    , koreTime + kTime
-                                    , accumulatedLogs
-                                    )
-                                    r{ExecuteRequest.state = execStateToKoreJson koreResult.state}
-                            | otherwise -> do
-                                -- otherwise we have hit a different
-                                -- HaltReason, at which point we should
-                                -- return, setting the correct depth
-                                Log.logInfoNS "proxy" . Text.pack $
-                                    "Kore " <> show koreResult.reason <> " at " <> show koreResult.depth
-                                logStats ExecuteM (time + bTime + kTime, koreTime + kTime)
-                                pure $
-                                    Right $
-                                        Execute
-                                            koreResult
-                                                { depth = currentDepth + boosterResult.depth + koreResult.depth
-                                                , logs = combineLogs [rpcLogs, boosterResult.logs, koreResult.logs]
+                    simplifyResult <- simplifyExecuteState logSettings r._module boosterResult.state
+                    case simplifyResult of
+                        Left logsOnly -> do
+                            -- state was simplified to \bottom, return vacuous
+                            Log.logInfoNS "proxy" "Vacuous state after simplification"
+                            pure . Right . Execute $ makeVacuous logsOnly boosterResult
+                        Right (simplifiedBoosterState, boosterStateSimplificationLogs) -> do
+                            -- attempt to do one step in the old backend
+                            (kResult, kTime) <-
+                                withTime $
+                                    kore
+                                        ( Execute
+                                            r
+                                                { state = execStateToKoreJson simplifiedBoosterState
+                                                , maxDepth = Just $ Depth 1
                                                 }
-                        -- can only be an error at this point
-                        res -> pure res
+                                        )
+                            when (isJust mbStatsVar) $
+                                Log.logInfoNS "proxy" . Text.pack $
+                                    "Kore fall-back in " <> microsWithUnit kTime
+                            case kResult of
+                                Right (Execute koreResult)
+                                    | koreResult.reason == DepthBound -> do
+                                        -- if we made one step, add the number of
+                                        -- steps we have taken to the counter and
+                                        -- attempt with booster again
+                                        when (koreResult.depth == 0) $ error "Expected kore-rpc to take at least one step"
+                                        Log.logInfoNS "proxy" $
+                                            Text.pack $
+                                                "kore depth-bound, continuing... (currently at "
+                                                    <> show (currentDepth + boosterResult.depth + koreResult.depth)
+                                                    <> ")"
+                                        let accumulatedLogs =
+                                                combineLogs
+                                                    [ rpcLogs
+                                                    , boosterResult.logs
+                                                    , boosterStateSimplificationLogs
+                                                    , koreResult.logs
+                                                    ]
+                                        executionLoop
+                                            logSettings
+                                            ( currentDepth + boosterResult.depth + koreResult.depth
+                                            , time + bTime + kTime
+                                            , koreTime + kTime
+                                            , accumulatedLogs
+                                            )
+                                            r{ExecuteRequest.state = execStateToKoreJson koreResult.state}
+                                    | otherwise -> do
+                                        -- otherwise we have hit a different
+                                        -- HaltReason, at which point we should
+                                        -- return, setting the correct depth
+                                        Log.logInfoNS "proxy" . Text.pack $
+                                            "Kore " <> show koreResult.reason <> " at " <> show koreResult.depth
+                                        logStats ExecuteM (time + bTime + kTime, koreTime + kTime)
+                                        pure $
+                                            Right $
+                                                Execute
+                                                    koreResult
+                                                        { depth = currentDepth + boosterResult.depth + koreResult.depth
+                                                        , logs = combineLogs [rpcLogs, boosterResult.logs, koreResult.logs]
+                                                        }
+                                -- can only be an error at this point
+                                res -> pure res
                 | otherwise -> do
                     -- we were successful with the booster, thus we
                     -- return the booster result with the updated
@@ -255,11 +261,15 @@ respondEither mbStatsVar booster kore req = case req of
             -- can only be an error at this point
             res -> pure res
 
+    -- Performs an internal simplify call for the given execute state.
+    -- If the state simplifies to bottom, only the logs are returned,
+    -- otherwise the logs and the simplified state (after splitting it
+    -- into term and predicates by an internal trivial execute call).
     simplifyExecuteState ::
         LogSettings ->
         Maybe Text ->
         ExecuteState ->
-        m (ExecuteState, Maybe [RPCLog.LogEntry])
+        m (Either (Maybe [RPCLog.LogEntry]) (ExecuteState, Maybe [RPCLog.LogEntry]))
     simplifyExecuteState
         LogSettings{logSuccessfulSimplifications, logFailedSimplifications}
         mbModule
@@ -270,28 +280,35 @@ respondEither mbStatsVar booster kore req = case req of
             case simplResult of
                 -- This request should not fail, as the only possible
                 -- failure mode would be malformed or invalid kore
-                Right (Simplify simplified) -> do
-                    -- to convert back to a term/constraints form,
-                    -- we run a trivial execute request (in booster)
-                    -- We cannot call the booster internaliser without access to the server state
-                    -- Again this should not fail.
-                    let request =
-                            (emptyExecuteRequest simplified.state)
-                                { _module = mbModule
-                                , maxDepth = Just $ Depth 0
-                                }
-                    Log.logInfoNS "proxy" "Making 0-step execute request to convert back to a term/constraints form"
-                    result <- booster $ Execute request
-                    case result of
-                        Right (Execute ExecuteResult{state = finalState}) ->
-                            -- return the state converted by the Booster and logs from simplification.
-                            -- The logs from the 0-step execute request because will be empty, we don't request them
-                            pure (finalState, combineLogs [simplified.logs])
-                        _other -> pure (s, Nothing)
+                Right (Simplify simplified)
+                    | KoreJson.KJBottom _ <- simplified.state.term ->
+                        pure (Left simplified.logs)
+                    | otherwise -> do
+                        -- to convert back to a term/constraints form,
+                        -- we run a trivial execute request (in booster)
+                        -- We cannot call the booster internaliser without access to the server state
+                        -- This call would fail for a \bottom state
+                        let request =
+                                (emptyExecuteRequest simplified.state)
+                                    { _module = mbModule
+                                    , maxDepth = Just $ Depth 0
+                                    }
+                        Log.logInfoNS "proxy" "Making 0-step execute request to convert back to a term/constraints form"
+                        result <- booster $ Execute request
+                        case result of
+                            Right (Execute ExecuteResult{state = finalState}) ->
+                                -- return state converted by Booster and logs from simplification.
+                                -- The 0-step execute result won't have logs (no logs are requested)
+                                pure $ Right (finalState, simplified.logs)
+                            other -> do
+                                Log.logWarnNS "proxy" $
+                                    "Error in pseudo-execute step after simplification: "
+                                        <> either (Text.pack . show) (Text.pack . show . encode) other
+                                pure $ Right (s, Nothing)
                 _other -> do
                     -- if we hit an error here, return the original
                     Log.logWarnNS "proxy" "Unexpected failure when calling Kore simplifier, returning original term"
-                    pure (s, Nothing)
+                    pure $ Right (s, Nothing)
           where
             toSimplifyRequest :: ExecuteState -> SimplifyRequest
             toSimplifyRequest state =
@@ -327,37 +344,42 @@ respondEither mbStatsVar booster kore req = case req of
         simplifyResult :: ExecuteResult -> m ExecuteResult
         simplifyResult res@ExecuteResult{reason, state, nextStates} = do
             Log.logInfoNS "proxy" . Text.pack $ "Simplifying state in " <> show reason <> " result"
-            (simplifiedState, simplifiedStateLogs) <- simplifyExecuteState logSettings mbModule state
-            simplifiedNexts <- maybe (pure []) (mapM $ simplifyExecuteState logSettings mbModule) nextStates
-            let (filteredNexts, filteredNextsLogs) = unzip . filter (not . isBottom . fst) $ simplifiedNexts
-            let result = case reason of
-                    Branching
-                        | null filteredNexts ->
-                            res{reason = Stuck, nextStates = Nothing}
-                        | length filteredNexts == 1 ->
-                            res -- What now? would have to re-loop. Return as-is.
-                            -- otherwise falling through to _otherReason
-                    CutPointRule
-                        | null filteredNexts ->
-                            -- HACK. Would want to return the prior state
-                            res{reason = Stuck, nextStates = Nothing}
-                    _otherReason ->
-                        res
-                            { state = simplifiedState
-                            , nextStates = if null filteredNexts then Nothing else Just filteredNexts
-                            }
-            let allLogs =
-                    if null filteredNexts
-                        then simplifiedStateLogs
-                        else combineLogs $ simplifiedStateLogs : filteredNextsLogs
-            pure $ appendLogs result allLogs
+            simplified <- simplifyExecuteState logSettings mbModule state
 
-        isBottom :: ExecuteState -> Bool
-        isBottom ExecuteState{term}
-            | KoreJson.KJBottom _ <- term.term = True
-        isBottom ExecuteState{predicate = Just p}
-            | KoreJson.KJBottom _ <- p.term = True
-        isBottom _ = False
+            case simplified of
+                Left logsOnly -> do
+                    -- state simplified to \bottom, return vacuous
+                    Log.logInfoNS "proxy" "Vacuous after simplifying result state"
+                    pure $ makeVacuous logsOnly res
+                Right (simplifiedState, simplifiedStateLogs) -> do
+                    simplifiedNexts <-
+                        maybe
+                            (pure [])
+                            (mapM $ simplifyExecuteState logSettings mbModule)
+                            nextStates
+                    let (logsOnly, (filteredNexts, filteredNextLogs)) =
+                            second unzip $ partitionEithers simplifiedNexts
+                        newLogs = simplifiedStateLogs : logsOnly <> filteredNextLogs
+
+                    pure $ case reason of
+                        Branching
+                            | null filteredNexts ->
+                                res{reason = Stuck, nextStates = Nothing}
+                            | length filteredNexts == 1 ->
+                                res -- What now? would have to re-loop. Return as-is.
+                                -- otherwise falling through to _otherReason
+                        CutPointRule
+                            | null filteredNexts ->
+                                makeVacuous (combineLogs newLogs) res
+                        _otherReason ->
+                            res
+                                { state = simplifiedState
+                                , nextStates =
+                                    if null filteredNexts
+                                        then Nothing
+                                        else Just filteredNexts
+                                , logs = combineLogs $ res.logs : newLogs
+                                }
 
 data LogSettings = LogSettings
     { logSuccessfulSimplifications :: Maybe Bool
@@ -372,6 +394,11 @@ combineLogs logSources
     | all isNothing logSources = Nothing
     | otherwise = Just $ concat $ catMaybes logSources
 
-appendLogs :: ExecuteResult -> Maybe [RPCLog.LogEntry] -> ExecuteResult
-appendLogs res@ExecuteResult{reason, logs} newLogs =
-    res{reason, logs = combineLogs [logs, newLogs]}
+makeVacuous :: Maybe [RPCLog.LogEntry] -> ExecuteResult -> ExecuteResult
+makeVacuous newLogs execState =
+    execState
+        { reason = Vacuous
+        , nextStates = Nothing
+        , rule = Nothing
+        , logs = combineLogs [execState.logs, newLogs]
+        }

--- a/tools/booster/Proxy.hs
+++ b/tools/booster/Proxy.hs
@@ -364,7 +364,11 @@ respondEither mbStatsVar booster kore req = case req of
                     pure $ case reason of
                         Branching
                             | null filteredNexts ->
-                                res{reason = Stuck, nextStates = Nothing, logs = combineLogs $ res.logs : simplifiedStateLogs : logsOnly}
+                                res
+                                    { reason = Stuck
+                                    , nextStates = Nothing
+                                    , logs = combineLogs $ res.logs : simplifiedStateLogs : logsOnly
+                                    }
                             | length filteredNexts == 1 ->
                                 res -- What now? would have to re-loop. Return as-is.
                                 -- otherwise falling through to _otherReason

--- a/tools/booster/Proxy.hs
+++ b/tools/booster/Proxy.hs
@@ -364,7 +364,7 @@ respondEither mbStatsVar booster kore req = case req of
                     pure $ case reason of
                         Branching
                             | null filteredNexts ->
-                                res{reason = Stuck, nextStates = Nothing}
+                                res{reason = Stuck, nextStates = Nothing, logs = combineLogs $ res.logs : simplifiedStateLogs : logsOnly}
                             | length filteredNexts == 1 ->
                                 res -- What now? would have to re-loop. Return as-is.
                                 -- otherwise falling through to _otherReason


### PR DESCRIPTION
This specifically handles cases where combinations of constraints make a configuration undefined (`\bottom`), as observed in #303 . The post-execution simplification should yield `vacuous` in such cases but was previously returning `stuck`.

Responses differ between `kore-rpc-dev` and `kore-rpc-booster` because `kore-rpc-dev` will detect the contradiction during the rewrite step (which includes simplification) and not perform the rewrite in such cases. Also, it returns `stuck` instead of `vacuous` if  the initial state is already `\bottom` (not to be addressed in this code). 

Also includes some refactoring for the previous code change in `Proxy.hs` (simpler handling of logs, dedicated type for log settings).

Fixes #303 