### PR TITLE
update JsonRpc to use AddModuleResult

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -17,7 +17,7 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/runtimeverification/haskell-backend.git
-    tag: 96545095d33235f3e8c91da7981cf28abbcdc679
-    --sha256: sha256-xI4xsZyeOrYjS8UGo7IpnxrHVxqCBdt7vZJXNA6M31w=
+    tag: 42c0c473c244c0117dc3241f8befcc02fa2bc37d
+    --sha256: sha256-2QErGkwVRHHQOb1AbKTTcS2ABPXkhTJJa3nMSQG9nOg=
     subdir: kore kore-rpc-types
 

--- a/flake.lock
+++ b/flake.lock
@@ -193,11 +193,11 @@
         "z3-src": "z3-src"
       },
       "locked": {
-        "lastModified": 1695315789,
-        "narHash": "sha256-GCGWVK7PM1iuQBkRJnf1OKLjfBjdC4xdJG3o1RalUC8=",
+        "lastModified": 1696402121,
+        "narHash": "sha256-eTE6khq9aXq+LQ7lyHBZThlC8b7aOfib09BsOm6gtiw=",
         "owner": "runtimeverification",
         "repo": "haskell-backend",
-        "rev": "96545095d33235f3e8c91da7981cf28abbcdc679",
+        "rev": "42c0c473c244c0117dc3241f8befcc02fa2bc37d",
         "type": "github"
       },
       "original": {

--- a/library/Booster/JsonRpc.hs
+++ b/library/Booster/JsonRpc.hs
@@ -137,7 +137,7 @@ respond stateVar =
                                 liftIO $ putMVar stateVar state{definitions = newDefinitions}
                                 Log.logInfo $
                                     "Added a new module. Now in scope: " <> Text.intercalate ", " (Map.keys newDefinitions)
-                                pure $ Right $ RpcTypes.AddModule ()
+                                pure $ Right $ RpcTypes.AddModule RpcTypes.AddModuleResult
         RpcTypes.Simplify req -> withContext req._module $ \(def, mLlvmLibrary) -> do
             start <- liftIO $ getTime Monotonic
             let internalised =

--- a/library/Booster/JsonRpc/Utils.hs
+++ b/library/Booster/JsonRpc/Utils.hs
@@ -117,7 +117,7 @@ decodeKoreRpc input =
                     [ Execute <$> parseMaybe (Json.parseJSON @ExecuteResult) resp.getResult
                     , Implies <$> parseMaybe (Json.parseJSON @ImpliesResult) resp.getResult
                     , Simplify <$> parseMaybe (Json.parseJSON @SimplifyResult) resp.getResult
-                    , AddModule <$> parseMaybe (Json.parseJSON @()) resp.getResult
+                    , AddModule <$> parseMaybe (Json.parseJSON @AddModuleResult) resp.getResult
                     , GetModel <$> parseMaybe (Json.parseJSON @GetModelResult) resp.getResult
                     ]
     rpcError =

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,7 +11,7 @@ extra-deps:
   - typerep-map-0.5.0.0
   - monad-validate-1.2.0.1
   - git: https://github.com/runtimeverification/haskell-backend.git
-    commit: 96545095d33235f3e8c91da7981cf28abbcdc679
+    commit: 42c0c473c244c0117dc3241f8befcc02fa2bc37d
     subdirs:
       - kore
       - kore-rpc-types

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -40,29 +40,29 @@ packages:
   original:
     hackage: monad-validate-1.2.0.1
 - completed:
-    commit: 96545095d33235f3e8c91da7981cf28abbcdc679
+    commit: 42c0c473c244c0117dc3241f8befcc02fa2bc37d
     git: https://github.com/runtimeverification/haskell-backend.git
     name: kore
     pantry-tree:
-      sha256: 9ebffb67377cfd8ce20cd62059039e74611a4ab554eacd798d86fd2948bdb276
+      sha256: ebff0f1d5cfe85fe5b3fa88353b84ef18ba4d231f9a5ba25e6e589631057eab4
       size: 44548
     subdir: kore
     version: 0.60.0.0
   original:
-    commit: 96545095d33235f3e8c91da7981cf28abbcdc679
+    commit: 42c0c473c244c0117dc3241f8befcc02fa2bc37d
     git: https://github.com/runtimeverification/haskell-backend.git
     subdir: kore
 - completed:
-    commit: 96545095d33235f3e8c91da7981cf28abbcdc679
+    commit: 42c0c473c244c0117dc3241f8befcc02fa2bc37d
     git: https://github.com/runtimeverification/haskell-backend.git
     name: kore-rpc-types
     pantry-tree:
-      sha256: 3033d5c31dc212c776c9eeccd473aa0fe19c4c8c97e5a84e9719276b839f43ce
+      sha256: 7de44d85cb98fc87835e4a7c31fb18b96ae570f198576ec442ed2fe4ad5ffff1
       size: 475
     subdir: kore-rpc-types
     version: 0.60.0.0
   original:
-    commit: 96545095d33235f3e8c91da7981cf28abbcdc679
+    commit: 42c0c473c244c0117dc3241f8befcc02fa2bc37d
     git: https://github.com/runtimeverification/haskell-backend.git
     subdir: kore-rpc-types
 snapshots:


### PR DESCRIPTION
Blocked on https://github.com/runtimeverification/haskell-backend/pull/3667

This PR makes the changes to the booster needed to keep it in sync with the above named PR.