### PR TITLE
Small tweaks to diff replacement code

### DIFF
--- a/cabal.project.freeze
+++ b/cabal.project.freeze
@@ -1,6 +1,5 @@
 active-repositories: hackage.haskell.org:merge
 constraints: any.Cabal ==3.6.3.0,
-             any.Diff ==0.4.1,
              any.Glob ==0.10.2,
              any.HUnit ==1.6.2.0,
              any.OneTuple ==0.3.1,

--- a/library/Booster/JsonRpc/Utils.hs
+++ b/library/Booster/JsonRpc/Utils.hs
@@ -21,8 +21,9 @@ import Data.Aeson.Types (parseMaybe)
 import Data.ByteString.Lazy.Char8 qualified as BS
 import Data.Maybe (fromMaybe)
 import Network.JSONRPC
-import System.IO (hFlush)
-import System.IO.Temp (withSystemTempFile)
+import System.Exit (ExitCode (..))
+import System.FilePath
+import System.IO.Extra (withTempDir)
 import System.IO.Unsafe (unsafePerformIO)
 import System.Process (readProcessWithExitCode)
 
@@ -201,17 +202,13 @@ rpcTypeOf = \case
         Cancel -> error "Cancel"
 
 -------------------------------------------------------------------
--- pretty diff output
--- Currently using a String-based module from the Diff package but
--- which should be rewritten to handle Text and Char8.ByteString
+-- doing the actual diff when output is requested
 
 renderDiff :: BS.ByteString -> BS.ByteString -> BS.ByteString
-renderDiff first second = unsafePerformIO $ do
-    withSystemTempFile "diff_file1.txt" $ \path1 handle1 -> do
-        withSystemTempFile "diff_file2.txt" $ \path2 handle2 -> do
-            BS.hPut handle1 first
-            BS.hPut handle2 second
-            hFlush handle1
-            hFlush handle2
-            (_, str, _) <- readProcessWithExitCode "diff" ["-w", path1, path2] ""
-            return $ BS.pack str
+renderDiff first second = unsafePerformIO . withTempDir $ \dir -> do
+    let path1 = dir </> "diff_file1.txt"
+        path2 = dir </> "diff_file2.txt"
+    BS.writeFile path1 first
+    BS.writeFile path2 second
+    (_, str, _) <- readProcessWithExitCode "diff" ["-w", path1, path2] ""
+    return $ BS.pack str

--- a/library/Booster/JsonRpc/Utils.hs
+++ b/library/Booster/JsonRpc/Utils.hs
@@ -210,5 +210,8 @@ renderDiff first second = unsafePerformIO . withTempDir $ \dir -> do
         path2 = dir </> "diff_file2.txt"
     BS.writeFile path1 first
     BS.writeFile path2 second
-    (_, str, _) <- readProcessWithExitCode "diff" ["-w", path1, path2] ""
-    return $ BS.pack str
+    (result, str, _) <- readProcessWithExitCode "diff" ["-w", path1, path2] ""
+    case result of
+        ExitSuccess -> error "Unexpected result: identical content"
+        ExitFailure 1 -> pure $ BS.pack str
+        ExitFailure n -> error $ "diff process exited with code " <> show n

--- a/package.yaml
+++ b/package.yaml
@@ -71,7 +71,6 @@ library:
   - containers
   - deepseq
   - deriving-aeson
-  - Diff
   - exceptions
   - extra
   - filepath
@@ -93,7 +92,6 @@ library:
   - stm-conduit
   - syb
   - template-haskell
-  - temporary
   - text
   - transformers
   - unix


### PR DESCRIPTION
* not using a library from 2018
* catching unexpected `diff` process results

We could go further and 
* eliminate `unsafePerformIO`
* only store the actual diff output inside `TextDiff` or `JsonDiff`  (the diff should always be non-empty)