### PR TITLE
Replace `llvm-backend-matching` with `llvm-kompile-matching`

### DIFF
--- a/test/rpc-integration/generateDirectoryTest.sh
+++ b/test/rpc-integration/generateDirectoryTest.sh
@@ -45,7 +45,7 @@ cat >>resources/$NAME.kompile <<EOL
 cp $NAME.haskell.kore $NAME.kore
 
 # Regenerate llvm backend decision tree
-llvm-backend-matching $NAME.llvm.kore qbaL ./dt 0
+llvm-kompile-matching $NAME.llvm.kore qbaL ./dt 0
 
 # kompile llvm-definition to interpreter
 

--- a/test/rpc-integration/generateDirectoryTest.sh
+++ b/test/rpc-integration/generateDirectoryTest.sh
@@ -45,6 +45,7 @@ cat >>resources/$NAME.kompile <<EOL
 cp $NAME.haskell.kore $NAME.kore
 
 # Regenerate llvm backend decision tree
+mkdir -p ./dt
 llvm-kompile-matching $NAME.llvm.kore qbaL ./dt 0
 
 # kompile llvm-definition to interpreter

--- a/test/rpc-integration/resources/foundry-bug-report.kompile
+++ b/test/rpc-integration/resources/foundry-bug-report.kompile
@@ -26,7 +26,7 @@ NAMETGZ=$(basename ${0%.kompile})
 cp foundry-bug-report.haskell.kore foundry-bug-report.kore
 
 # Regenerate llvm backend decision tree
-llvm-backend-matching foundry-bug-report.llvm.kore qbaL ./dt 0
+llvm-kompile-matching foundry-bug-report.llvm.kore qbaL ./dt 0
 
 # kompile llvm-definition to interpreter
 

--- a/test/rpc-integration/resources/foundry-bug-report.kompile
+++ b/test/rpc-integration/resources/foundry-bug-report.kompile
@@ -26,6 +26,7 @@ NAMETGZ=$(basename ${0%.kompile})
 cp foundry-bug-report.haskell.kore foundry-bug-report.kore
 
 # Regenerate llvm backend decision tree
+mkdir -p ./dt
 llvm-kompile-matching foundry-bug-report.llvm.kore qbaL ./dt 0
 
 # kompile llvm-definition to interpreter

--- a/test/rpc-integration/resources/foundry-bug-report.tar.gz.kompile
+++ b/test/rpc-integration/resources/foundry-bug-report.tar.gz.kompile
@@ -31,6 +31,7 @@ tar xzf ../test-$NAMETGZ -C $NAME definition.kore llvm_definition/definition.kor
 cp $NAME/definition.kore ${NAMETGZ}.kore
 
 # Regenerate llvm backend decision tree
+mkdir -p $NAME/llvm_definition/dt
 llvm-kompile-matching $NAME/llvm_definition/definition.kore qbaL $NAME/llvm_definition/dt 0
 
 # kompile llvm-definition to interpreter

--- a/test/rpc-integration/resources/foundry-bug-report.tar.gz.kompile
+++ b/test/rpc-integration/resources/foundry-bug-report.tar.gz.kompile
@@ -31,7 +31,7 @@ tar xzf ../test-$NAMETGZ -C $NAME definition.kore llvm_definition/definition.kor
 cp $NAME/definition.kore ${NAMETGZ}.kore
 
 # Regenerate llvm backend decision tree
-llvm-backend-matching $NAME/llvm_definition/definition.kore qbaL $NAME/llvm_definition/dt 0
+llvm-kompile-matching $NAME/llvm_definition/definition.kore qbaL $NAME/llvm_definition/dt 0
 
 # kompile llvm-definition to interpreter
 


### PR DESCRIPTION
Now that we have `llvm-kompile-matching` (https://github.com/runtimeverification/k/pull/3659) in K, replacing `llvm-backend-matching`, we can replace the calls and remove `llvm-backend-matching` from the llvm repo