### PR TITLE
Do not simplify before calling kore-rpc

### DIFF
--- a/library/Booster/JsonRpc.hs
+++ b/library/Booster/JsonRpc.hs
@@ -180,19 +180,9 @@ respond stateVar =
                                 predicate = fromMaybe (KoreJson.KJTop tSort) mbPredicate
                                 substitution = fromMaybe (KoreJson.KJTop tSort) mbSubstitution
                                 result = KoreJson.KJAnd tSort [term, predicate, substitution]
-                            -- pure . Right . RpcTypes.Simplify $
-                            --     RpcTypes.SimplifyResult
-                            --         { state = addHeader result
-                            --         , logs = mkTraces patternTraces
-                            --         }
                             pure $ Right (addHeader result, patternTraces)
                         (Left ApplyEquations.SideConditionsFalse{}, patternTraces, _) -> do
                             let tSort = fromMaybe (error "unknown sort") $ sortOfJson req.state.term
-                            -- pure . Right . RpcTypes.Simplify $
-                            --     RpcTypes.SimplifyResult
-                            --         { state = addHeader $ KoreJson.KJBottom tSort
-                            --         , logs = mkTraces patternTraces
-                            --         }
                             pure $ Right (addHeader $ KoreJson.KJBottom tSort, patternTraces)
                         (Left (ApplyEquations.EquationLoop terms), _traces, _) ->
                             pure . Left . RpcError.backendError RpcError.Aborted $ map externaliseTerm terms -- FIXME
@@ -207,11 +197,6 @@ respond stateVar =
                                     fromMaybe (error "not a predicate") $
                                         sortOfJson req.state.term
                                 result = externalisePredicate predicateSort newPred
-                            -- pure . Right . RpcTypes.Simplify $
-                            --     RpcTypes.SimplifyResult
-                            --         { state = addHeader result
-                            --         , logs = mkTraces traces
-                            --         }
                             pure $ Right (addHeader result, traces)
                         (Left something, _traces, _) ->
                             pure . Left . RpcError.backendError RpcError.Aborted $ show something -- FIXME

--- a/scripts/compare.py
+++ b/scripts/compare.py
@@ -77,7 +77,7 @@ column_width3 = max([len(c[3]) for c in final_table])
 def mkColumn(c, w):
     return ' ' + c.ljust(w) + ' '
 
-columns = ['|'.join((mkColumn(c0, column_width0), mkColumn(c1, column_width1), mkColumn(c2, column_width2), mkColumn(c3, column_width3))) for (c0, c1, c2, c3) in final_table]
-columns[1] = columns[1].replace('|', '+').replace(' ', '-')
+columns = ['|' + '|'.join((mkColumn(c0, column_width0), mkColumn(c1, column_width1), mkColumn(c2, column_width2), mkColumn(c3, column_width3))) for (c0, c1, c2, c3) in final_table]
+columns[1] = columns[1].replace(' ', '-')
 
 print('\n'.join(columns))

--- a/scripts/compare.py
+++ b/scripts/compare.py
@@ -1,13 +1,28 @@
 #!/usr/bin/env python3
 
 import sys
+import re
 
 logfile_1 = sys.argv[1]
 logfile_2 = sys.argv[2]
-mintime   = 0.01
-# minchange = 0.035
-minchange = 0.035
-  
+if len(sys.argv) > 3:
+    mintime = float(sys.argv[3])
+else:
+    mintime = 0.01
+if len(sys.argv) > 4:
+    minchange = float(sys.argv[4])
+else:
+    minchange = 0.035
+
+testname = re.compile(r'^src/.*\[(?P<name>.*)\]$')
+
+def readName(input):
+    r = testname.match(input)
+    if r is None:
+        return input
+    else:
+        return r.group("name")
+
 def readData(file_name):
     data_lines = []
     with open(file_name, 'r') as file_data:
@@ -15,7 +30,7 @@ def readData(file_name):
             data_line = [l for l in line.strip('\n').split(' ') if l != '']
             if data_line[1] == 'call':
                 time = float(data_line[0][:-1])
-                test = data_line[2]
+                test = readName(data_line[2])
                 if time > 0.5:
                     data_lines.append((test, time))
     return data_lines
@@ -35,7 +50,7 @@ def filterEntries(test, t1, t2):
     return (t1 != t2)                                                   \
        and (t1 > mintime or t2 > mintime)                               \
        and ((t1 / t2) - 1.0 > minchange or (t2 / t1) - 1.0 > minchange)
-    
+
 # test , time1 , time2 , time1 / time2
 final_table = []
 for test in common_passing_tests:

--- a/scripts/performance-tests-kevm.sh
+++ b/scripts/performance-tests-kevm.sh
@@ -5,7 +5,7 @@ set -euxo pipefail
 #  https://github.com/pypa/pip/issues/7883
 export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring
 
-KEVM_VERSION=${KEVM_VERSION:-'v1.0.335'}
+KEVM_VERSION=${KEVM_VERSION:-'master'}
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
@@ -31,7 +31,7 @@ fi
 
 # Make sure the temp directory gets removed and kore-rpc-booster gets killed on script exit.
 trap "exit 1"           HUP INT PIPE QUIT TERM
-trap 'rm -rf "$TEMPD" && killall kore-rpc-booster || echo "No zombie processes found'  EXIT
+trap 'rm -rf "$TEMPD" && killall kore-rpc-booster || echo "No zombie processes found"'  EXIT
 
 feature_shell() {
   GC_DONT_GC=1 nix develop . --extra-experimental-features 'nix-command flakes' --override-input k-framework/booster-backend $SCRIPT_DIR/../ --command bash -c "$1"
@@ -44,11 +44,12 @@ master_shell() {
 cd $TEMPD
 git clone --depth 1 --branch $KEVM_VERSION https://github.com/runtimeverification/evm-semantics.git
 cd evm-semantics
+
+KEVM_VERSION=${KEVM_VERSION}-$(git rev-parse --short ${KEVM_VERSION})
 git submodule update --init --recursive --depth 1 kevm-pyk/src/kevm_pyk/kproj/plugin
 
 
-
-feature_shell "make poetry && poetry run -C kevm-pyk -- kevm-dist --verbose build plugin haskell --jobs 4"
+feature_shell "make poetry && poetry run -C kevm-pyk -- kevm-dist --verbose build evm-semantics.plugin evm-semantics.haskell --jobs 4"
 
 feature_shell "make test-prove-pyk PYTEST_PARALLEL=$PYTEST_PARALLEL PYTEST_ARGS='--maxfail=0 --timeout 7200 -vv --use-booster' | tee $SCRIPT_DIR/kevm-$KEVM_VERSION-$FEATURE_BRANCH_NAME.log"
 killall kore-rpc-booster || echo "No zombie processes found"

--- a/scripts/performance-tests-kevm.sh
+++ b/scripts/performance-tests-kevm.sh
@@ -31,7 +31,7 @@ fi
 
 # Make sure the temp directory gets removed and kore-rpc-booster gets killed on script exit.
 trap "exit 1"           HUP INT PIPE QUIT TERM
-trap 'rm -rf "$TEMPD" && killall kore-rpc-booster'  EXIT
+trap 'rm -rf "$TEMPD" && killall kore-rpc-booster || echo "No zombie processes found'  EXIT
 
 feature_shell() {
   GC_DONT_GC=1 nix develop . --extra-experimental-features 'nix-command flakes' --override-input k-framework/booster-backend $SCRIPT_DIR/../ --command bash -c "$1"
@@ -51,11 +51,11 @@ git submodule update --init --recursive --depth 1 kevm-pyk/src/kevm_pyk/kproj/pl
 feature_shell "make poetry && poetry run -C kevm-pyk -- kevm-dist --verbose build plugin haskell --jobs 4"
 
 feature_shell "make test-prove-pyk PYTEST_PARALLEL=$PYTEST_PARALLEL PYTEST_ARGS='--maxfail=0 --timeout 7200 -vv --use-booster' | tee $SCRIPT_DIR/kevm-$KEVM_VERSION-$FEATURE_BRANCH_NAME.log"
-killall kore-rpc-booster
+killall kore-rpc-booster || echo "No zombie processes found"
 
 if [ ! -e "$SCRIPT_DIR/kevm-$KEVM_VERSION-master-$MASTER_COMMIT.log" ]; then
   master_shell "make test-prove-pyk PYTEST_PARALLEL=$PYTEST_PARALLEL PYTEST_ARGS='--maxfail=0 --timeout 7200 -vv --use-booster' | tee $SCRIPT_DIR/kevm-$KEVM_VERSION-master-$MASTER_COMMIT.log"
-  killall kore-rpc-booster
+  killall kore-rpc-booster || echo "No zombie processes found"
 fi
 
 cd $SCRIPT_DIR

--- a/scripts/performance-tests-kontrol.sh
+++ b/scripts/performance-tests-kontrol.sh
@@ -31,7 +31,7 @@ fi
 
 # Make sure the temp directory gets removed and kore-rpc-booster gets killed on script exit.
 trap "exit 1"           HUP INT PIPE QUIT TERM
-trap 'rm -rf "$TEMPD" && killall kore-rpc-booster'  EXIT
+trap 'rm -rf "$TEMPD" && killall kore-rpc-booster || echo "no zombie processes found"'  EXIT
 
 cd $TEMPD
 git clone --depth 1 --branch $KONTROL_VERSION https://github.com/runtimeverification/kontrol.git
@@ -63,11 +63,11 @@ master_shell() {
 feature_shell "poetry install && poetry run kevm-dist --verbose build plugin haskell foundry --jobs 4"
 
 feature_shell "make test-integration TEST_ARGS='--maxfail=0 --numprocesses=$PYTEST_PARALLEL --use-booster -vv' | tee $SCRIPT_DIR/kontrol-$KONTROL_VERSION-$FEATURE_BRANCH_NAME.log"
-killall kore-rpc-booster
+killall kore-rpc-booster || echo "no zombie processes found"
 
 if [ ! -e "$SCRIPT_DIR/kontrol-$KONTROL_VERSION-master-$MASTER_COMMIT.log" ]; then
   master_shell "make test-integration TEST_ARGS='--maxfail=0 --numprocesses=$PYTEST_PARALLEL --use-booster -vv' | tee $SCRIPT_DIR/kontrol-$KONTROL_VERSION-master-$MASTER_COMMIT.log"
-  killall kore-rpc-booster
+  killall kore-rpc-booster || echo "no zombie processes found"
 fi
 
 cd $SCRIPT_DIR

--- a/test/rpc-integration/test-vacuous/response-vacuous-at-branch.json
+++ b/test/rpc-integration/test-vacuous/response-vacuous-at-branch.json
@@ -9,141 +9,147 @@
                 "format": "KORE",
                 "version": 1,
                 "term": {
-                    "tag": "App",
-                    "name": "Lbl'-LT-'generatedTop'-GT-'",
-                    "sorts": [],
-                    "args": [
+                    "tag": "And",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortGeneratedTopCell",
+                        "args": []
+                    },
+                    "patterns": [
                         {
                             "tag": "App",
-                            "name": "Lbl'-LT-'k'-GT-'",
+                            "name": "Lbl'-LT-'generatedTop'-GT-'",
                             "sorts": [],
                             "args": [
                                 {
                                     "tag": "App",
-                                    "name": "kseq",
+                                    "name": "Lbl'-LT-'k'-GT-'",
                                     "sorts": [],
                                     "args": [
                                         {
                                             "tag": "App",
-                                            "name": "inj",
-                                            "sorts": [
-                                                {
-                                                    "tag": "SortApp",
-                                                    "name": "SortState",
-                                                    "args": []
-                                                },
-                                                {
-                                                    "tag": "SortApp",
-                                                    "name": "SortKItem",
-                                                    "args": []
-                                                }
-                                            ],
+                                            "name": "kseq",
+                                            "sorts": [],
                                             "args": [
                                                 {
-                                                    "tag": "DV",
-                                                    "sort": {
-                                                        "tag": "SortApp",
-                                                        "name": "SortState",
-                                                        "args": []
-                                                    },
-                                                    "value": "a"
+                                                    "tag": "App",
+                                                    "name": "inj",
+                                                    "sorts": [
+                                                        {
+                                                            "tag": "SortApp",
+                                                            "name": "SortState",
+                                                            "args": []
+                                                        },
+                                                        {
+                                                            "tag": "SortApp",
+                                                            "name": "SortKItem",
+                                                            "args": []
+                                                        }
+                                                    ],
+                                                    "args": [
+                                                        {
+                                                            "tag": "DV",
+                                                            "sort": {
+                                                                "tag": "SortApp",
+                                                                "name": "SortState",
+                                                                "args": []
+                                                            },
+                                                            "value": "a"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "tag": "App",
+                                                    "name": "dotk",
+                                                    "sorts": [],
+                                                    "args": []
                                                 }
                                             ]
-                                        },
+                                        }
+                                    ]
+                                },
+                                {
+                                    "tag": "App",
+                                    "name": "Lbl'-LT-'int'-GT-'",
+                                    "sorts": [],
+                                    "args": [
                                         {
-                                            "tag": "App",
-                                            "name": "dotk",
-                                            "sorts": [],
-                                            "args": []
+                                            "tag": "DV",
+                                            "sort": {
+                                                "tag": "SortApp",
+                                                "name": "SortInt",
+                                                "args": []
+                                            },
+                                            "value": "0"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "tag": "App",
+                                    "name": "Lbl'-LT-'generatedCounter'-GT-'",
+                                    "sorts": [],
+                                    "args": [
+                                        {
+                                            "tag": "DV",
+                                            "sort": {
+                                                "tag": "SortApp",
+                                                "name": "SortInt",
+                                                "args": []
+                                            },
+                                            "value": "0"
                                         }
                                     ]
                                 }
                             ]
                         },
                         {
-                            "tag": "App",
-                            "name": "Lbl'-LT-'int'-GT-'",
-                            "sorts": [],
-                            "args": [
-                                {
-                                    "tag": "DV",
-                                    "sort": {
-                                        "tag": "SortApp",
-                                        "name": "SortInt",
-                                        "args": []
+                            "tag": "Equals",
+                            "argSort": {
+                                "tag": "SortApp",
+                                "name": "SortBool",
+                                "args": []
+                            },
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortGeneratedTopCell",
+                                "args": []
+                            },
+                            "first": {
+                                "tag": "App",
+                                "name": "Lbl'UndsEqlsEqls'Int'Unds'",
+                                "sorts": [],
+                                "args": [
+                                    {
+                                        "tag": "DV",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortInt",
+                                            "args": []
+                                        },
+                                        "value": "0"
                                     },
-                                    "value": "0"
-                                }
-                            ]
-                        },
-                        {
-                            "tag": "App",
-                            "name": "Lbl'-LT-'generatedCounter'-GT-'",
-                            "sorts": [],
-                            "args": [
-                                {
-                                    "tag": "DV",
-                                    "sort": {
-                                        "tag": "SortApp",
-                                        "name": "SortInt",
-                                        "args": []
-                                    },
-                                    "value": "0"
-                                }
-                            ]
+                                    {
+                                        "tag": "DV",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortInt",
+                                            "args": []
+                                        },
+                                        "value": "42"
+                                    }
+                                ]
+                            },
+                            "second": {
+                                "tag": "DV",
+                                "sort": {
+                                    "tag": "SortApp",
+                                    "name": "SortBool",
+                                    "args": []
+                                },
+                                "value": "true"
+                            }
                         }
                     ]
-                }
-            },
-            "predicate": {
-                "format": "KORE",
-                "version": 1,
-                "term": {
-                    "tag": "Equals",
-                    "argSort": {
-                        "tag": "SortApp",
-                        "name": "SortBool",
-                        "args": []
-                    },
-                    "sort": {
-                        "tag": "SortApp",
-                        "name": "SortGeneratedTopCell",
-                        "args": []
-                    },
-                    "first": {
-                        "tag": "App",
-                        "name": "Lbl'UndsEqlsEqls'Int'Unds'",
-                        "sorts": [],
-                        "args": [
-                            {
-                                "tag": "DV",
-                                "sort": {
-                                    "tag": "SortApp",
-                                    "name": "SortInt",
-                                    "args": []
-                                },
-                                "value": "0"
-                            },
-                            {
-                                "tag": "DV",
-                                "sort": {
-                                    "tag": "SortApp",
-                                    "name": "SortInt",
-                                    "args": []
-                                },
-                                "value": "42"
-                            }
-                        ]
-                    },
-                    "second": {
-                        "tag": "DV",
-                        "sort": {
-                            "tag": "SortApp",
-                            "name": "SortBool",
-                            "args": []
-                        },
-                        "value": "true"
-                    }
                 }
             }
         }

--- a/test/rpc-integration/test-vacuous/response-vacuous-but-rewritten.json
+++ b/test/rpc-integration/test-vacuous/response-vacuous-but-rewritten.json
@@ -9,169 +9,68 @@
                 "format": "KORE",
                 "version": 1,
                 "term": {
-                    "tag": "App",
-                    "name": "Lbl'-LT-'generatedTop'-GT-'",
-                    "sorts": [],
-                    "args": [
-                        {
-                            "tag": "App",
-                            "name": "Lbl'-LT-'k'-GT-'",
-                            "sorts": [],
-                            "args": [
-                                {
-                                    "tag": "App",
-                                    "name": "kseq",
-                                    "sorts": [],
-                                    "args": [
-                                        {
-                                            "tag": "App",
-                                            "name": "inj",
-                                            "sorts": [
-                                                {
-                                                    "tag": "SortApp",
-                                                    "name": "SortState",
-                                                    "args": []
-                                                },
-                                                {
-                                                    "tag": "SortApp",
-                                                    "name": "SortKItem",
-                                                    "args": []
-                                                }
-                                            ],
-                                            "args": [
-                                                {
-                                                    "tag": "DV",
-                                                    "sort": {
-                                                        "tag": "SortApp",
-                                                        "name": "SortState",
-                                                        "args": []
-                                                    },
-                                                    "value": "d"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "tag": "App",
-                                            "name": "dotk",
-                                            "sorts": [],
-                                            "args": []
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "tag": "App",
-                            "name": "Lbl'-LT-'int'-GT-'",
-                            "sorts": [],
-                            "args": [
-                                {
-                                    "tag": "EVar",
-                                    "name": "N",
-                                    "sort": {
-                                        "tag": "SortApp",
-                                        "name": "SortInt",
-                                        "args": []
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "tag": "App",
-                            "name": "Lbl'-LT-'generatedCounter'-GT-'",
-                            "sorts": [],
-                            "args": [
-                                {
-                                    "tag": "DV",
-                                    "sort": {
-                                        "tag": "SortApp",
-                                        "name": "SortInt",
-                                        "args": []
-                                    },
-                                    "value": "0"
-                                }
-                            ]
-                        }
-                    ]
-                }
-            },
-            "predicate": {
-                "format": "KORE",
-                "version": 1,
-                "term": {
                     "tag": "And",
                     "sort": {
                         "tag": "SortApp",
                         "name": "SortGeneratedTopCell",
                         "args": []
                     },
-                    "first": {
-                        "tag": "Equals",
-                        "argSort": {
-                            "tag": "SortApp",
-                            "name": "SortBool",
-                            "args": []
-                        },
-                        "sort": {
-                            "tag": "SortApp",
-                            "name": "SortGeneratedTopCell",
-                            "args": []
-                        },
-                        "first": {
+                    "patterns": [
+                        {
                             "tag": "App",
-                            "name": "Lbl'UndsEqlsEqls'Int'Unds'",
-                            "sorts": [],
-                            "args": [
-                                {
-                                    "tag": "EVar",
-                                    "name": "N",
-                                    "sort": {
-                                        "tag": "SortApp",
-                                        "name": "SortInt",
-                                        "args": []
-                                    }
-                                },
-                                {
-                                    "tag": "DV",
-                                    "sort": {
-                                        "tag": "SortApp",
-                                        "name": "SortInt",
-                                        "args": []
-                                    },
-                                    "value": "0"
-                                }
-                            ]
-                        },
-                        "second": {
-                            "tag": "DV",
-                            "sort": {
-                                "tag": "SortApp",
-                                "name": "SortBool",
-                                "args": []
-                            },
-                            "value": "true"
-                        }
-                    },
-                    "second": {
-                        "tag": "Equals",
-                        "argSort": {
-                            "tag": "SortApp",
-                            "name": "SortBool",
-                            "args": []
-                        },
-                        "sort": {
-                            "tag": "SortApp",
-                            "name": "SortGeneratedTopCell",
-                            "args": []
-                        },
-                        "first": {
-                            "tag": "App",
-                            "name": "LblnotBool'Unds'",
+                            "name": "Lbl'-LT-'generatedTop'-GT-'",
                             "sorts": [],
                             "args": [
                                 {
                                     "tag": "App",
-                                    "name": "Lbl'UndsEqlsEqls'Int'Unds'",
+                                    "name": "Lbl'-LT-'k'-GT-'",
+                                    "sorts": [],
+                                    "args": [
+                                        {
+                                            "tag": "App",
+                                            "name": "kseq",
+                                            "sorts": [],
+                                            "args": [
+                                                {
+                                                    "tag": "App",
+                                                    "name": "inj",
+                                                    "sorts": [
+                                                        {
+                                                            "tag": "SortApp",
+                                                            "name": "SortState",
+                                                            "args": []
+                                                        },
+                                                        {
+                                                            "tag": "SortApp",
+                                                            "name": "SortKItem",
+                                                            "args": []
+                                                        }
+                                                    ],
+                                                    "args": [
+                                                        {
+                                                            "tag": "DV",
+                                                            "sort": {
+                                                                "tag": "SortApp",
+                                                                "name": "SortState",
+                                                                "args": []
+                                                            },
+                                                            "value": "d"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "tag": "App",
+                                                    "name": "dotk",
+                                                    "sorts": [],
+                                                    "args": []
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "tag": "App",
+                                    "name": "Lbl'-LT-'int'-GT-'",
                                     "sorts": [],
                                     "args": [
                                         {
@@ -182,7 +81,14 @@
                                                 "name": "SortInt",
                                                 "args": []
                                             }
-                                        },
+                                        }
+                                    ]
+                                },
+                                {
+                                    "tag": "App",
+                                    "name": "Lbl'-LT-'generatedCounter'-GT-'",
+                                    "sorts": [],
+                                    "args": [
                                         {
                                             "tag": "DV",
                                             "sort": {
@@ -196,16 +102,118 @@
                                 }
                             ]
                         },
-                        "second": {
-                            "tag": "DV",
+                        {
+                            "tag": "And",
                             "sort": {
                                 "tag": "SortApp",
-                                "name": "SortBool",
+                                "name": "SortGeneratedTopCell",
                                 "args": []
                             },
-                            "value": "true"
+                            "patterns": [
+                                {
+                                    "tag": "Equals",
+                                    "argSort": {
+                                        "tag": "SortApp",
+                                        "name": "SortBool",
+                                        "args": []
+                                    },
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortGeneratedTopCell",
+                                        "args": []
+                                    },
+                                    "first": {
+                                        "tag": "App",
+                                        "name": "Lbl'UndsEqlsEqls'Int'Unds'",
+                                        "sorts": [],
+                                        "args": [
+                                            {
+                                                "tag": "EVar",
+                                                "name": "N",
+                                                "sort": {
+                                                    "tag": "SortApp",
+                                                    "name": "SortInt",
+                                                    "args": []
+                                                }
+                                            },
+                                            {
+                                                "tag": "DV",
+                                                "sort": {
+                                                    "tag": "SortApp",
+                                                    "name": "SortInt",
+                                                    "args": []
+                                                },
+                                                "value": "0"
+                                            }
+                                        ]
+                                    },
+                                    "second": {
+                                        "tag": "DV",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortBool",
+                                            "args": []
+                                        },
+                                        "value": "true"
+                                    }
+                                },
+                                {
+                                    "tag": "Equals",
+                                    "argSort": {
+                                        "tag": "SortApp",
+                                        "name": "SortBool",
+                                        "args": []
+                                    },
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortGeneratedTopCell",
+                                        "args": []
+                                    },
+                                    "first": {
+                                        "tag": "App",
+                                        "name": "LblnotBool'Unds'",
+                                        "sorts": [],
+                                        "args": [
+                                            {
+                                                "tag": "App",
+                                                "name": "Lbl'UndsEqlsEqls'Int'Unds'",
+                                                "sorts": [],
+                                                "args": [
+                                                    {
+                                                        "tag": "EVar",
+                                                        "name": "N",
+                                                        "sort": {
+                                                            "tag": "SortApp",
+                                                            "name": "SortInt",
+                                                            "args": []
+                                                        }
+                                                    },
+                                                    {
+                                                        "tag": "DV",
+                                                        "sort": {
+                                                            "tag": "SortApp",
+                                                            "name": "SortInt",
+                                                            "args": []
+                                                        },
+                                                        "value": "0"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "second": {
+                                        "tag": "DV",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortBool",
+                                            "args": []
+                                        },
+                                        "value": "true"
+                                    }
+                                }
+                            ]
                         }
-                    }
+                    ]
                 }
             }
         }

--- a/test/rpc-integration/test-vacuous/response-vacuous-var-at-branch.json
+++ b/test/rpc-integration/test-vacuous/response-vacuous-var-at-branch.json
@@ -9,196 +9,204 @@
                 "format": "KORE",
                 "version": 1,
                 "term": {
-                    "tag": "App",
-                    "name": "Lbl'-LT-'generatedTop'-GT-'",
-                    "sorts": [],
-                    "args": [
-                        {
-                            "tag": "App",
-                            "name": "Lbl'-LT-'k'-GT-'",
-                            "sorts": [],
-                            "args": [
-                                {
-                                    "tag": "App",
-                                    "name": "kseq",
-                                    "sorts": [],
-                                    "args": [
-                                        {
-                                            "tag": "App",
-                                            "name": "inj",
-                                            "sorts": [
-                                                {
-                                                    "tag": "SortApp",
-                                                    "name": "SortState",
-                                                    "args": []
-                                                },
-                                                {
-                                                    "tag": "SortApp",
-                                                    "name": "SortKItem",
-                                                    "args": []
-                                                }
-                                            ],
-                                            "args": [
-                                                {
-                                                    "tag": "DV",
-                                                    "sort": {
-                                                        "tag": "SortApp",
-                                                        "name": "SortState",
-                                                        "args": []
-                                                    },
-                                                    "value": "a"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "tag": "App",
-                                            "name": "dotk",
-                                            "sorts": [],
-                                            "args": []
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "tag": "App",
-                            "name": "Lbl'-LT-'int'-GT-'",
-                            "sorts": [],
-                            "args": [
-                                {
-                                    "tag": "EVar",
-                                    "name": "N",
-                                    "sort": {
-                                        "tag": "SortApp",
-                                        "name": "SortInt",
-                                        "args": []
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "tag": "App",
-                            "name": "Lbl'-LT-'generatedCounter'-GT-'",
-                            "sorts": [],
-                            "args": [
-                                {
-                                    "tag": "DV",
-                                    "sort": {
-                                        "tag": "SortApp",
-                                        "name": "SortInt",
-                                        "args": []
-                                    },
-                                    "value": "0"
-                                }
-                            ]
-                        }
-                    ]
-                }
-            },
-            "predicate": {
-                "format": "KORE",
-                "version": 1,
-                "term": {
                     "tag": "And",
                     "sort": {
                         "tag": "SortApp",
                         "name": "SortGeneratedTopCell",
                         "args": []
                     },
-                    "first": {
-                        "tag": "Equals",
-                        "argSort": {
-                            "tag": "SortApp",
-                            "name": "SortBool",
-                            "args": []
-                        },
-                        "sort": {
-                            "tag": "SortApp",
-                            "name": "SortGeneratedTopCell",
-                            "args": []
-                        },
-                        "first": {
+                    "patterns": [
+                        {
                             "tag": "App",
-                            "name": "Lbl'UndsEqlsEqls'Int'Unds'",
+                            "name": "Lbl'-LT-'generatedTop'-GT-'",
                             "sorts": [],
                             "args": [
                                 {
-                                    "tag": "EVar",
-                                    "name": "N",
-                                    "sort": {
-                                        "tag": "SortApp",
-                                        "name": "SortInt",
-                                        "args": []
-                                    }
+                                    "tag": "App",
+                                    "name": "Lbl'-LT-'k'-GT-'",
+                                    "sorts": [],
+                                    "args": [
+                                        {
+                                            "tag": "App",
+                                            "name": "kseq",
+                                            "sorts": [],
+                                            "args": [
+                                                {
+                                                    "tag": "App",
+                                                    "name": "inj",
+                                                    "sorts": [
+                                                        {
+                                                            "tag": "SortApp",
+                                                            "name": "SortState",
+                                                            "args": []
+                                                        },
+                                                        {
+                                                            "tag": "SortApp",
+                                                            "name": "SortKItem",
+                                                            "args": []
+                                                        }
+                                                    ],
+                                                    "args": [
+                                                        {
+                                                            "tag": "DV",
+                                                            "sort": {
+                                                                "tag": "SortApp",
+                                                                "name": "SortState",
+                                                                "args": []
+                                                            },
+                                                            "value": "a"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "tag": "App",
+                                                    "name": "dotk",
+                                                    "sorts": [],
+                                                    "args": []
+                                                }
+                                            ]
+                                        }
+                                    ]
                                 },
                                 {
-                                    "tag": "DV",
-                                    "sort": {
-                                        "tag": "SortApp",
-                                        "name": "SortInt",
-                                        "args": []
-                                    },
-                                    "value": "42"
+                                    "tag": "App",
+                                    "name": "Lbl'-LT-'int'-GT-'",
+                                    "sorts": [],
+                                    "args": [
+                                        {
+                                            "tag": "EVar",
+                                            "name": "N",
+                                            "sort": {
+                                                "tag": "SortApp",
+                                                "name": "SortInt",
+                                                "args": []
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "tag": "App",
+                                    "name": "Lbl'-LT-'generatedCounter'-GT-'",
+                                    "sorts": [],
+                                    "args": [
+                                        {
+                                            "tag": "DV",
+                                            "sort": {
+                                                "tag": "SortApp",
+                                                "name": "SortInt",
+                                                "args": []
+                                            },
+                                            "value": "0"
+                                        }
+                                    ]
                                 }
                             ]
                         },
-                        "second": {
-                            "tag": "DV",
+                        {
+                            "tag": "And",
                             "sort": {
                                 "tag": "SortApp",
-                                "name": "SortBool",
+                                "name": "SortGeneratedTopCell",
                                 "args": []
                             },
-                            "value": "true"
-                        }
-                    },
-                    "second": {
-                        "tag": "Equals",
-                        "argSort": {
-                            "tag": "SortApp",
-                            "name": "SortBool",
-                            "args": []
-                        },
-                        "sort": {
-                            "tag": "SortApp",
-                            "name": "SortGeneratedTopCell",
-                            "args": []
-                        },
-                        "first": {
-                            "tag": "App",
-                            "name": "Lbl'UndsEqlsEqls'Int'Unds'",
-                            "sorts": [],
-                            "args": [
+                            "patterns": [
                                 {
-                                    "tag": "EVar",
-                                    "name": "N",
+                                    "tag": "Equals",
+                                    "argSort": {
+                                        "tag": "SortApp",
+                                        "name": "SortBool",
+                                        "args": []
+                                    },
                                     "sort": {
                                         "tag": "SortApp",
-                                        "name": "SortInt",
+                                        "name": "SortGeneratedTopCell",
                                         "args": []
+                                    },
+                                    "first": {
+                                        "tag": "App",
+                                        "name": "Lbl'UndsEqlsEqls'Int'Unds'",
+                                        "sorts": [],
+                                        "args": [
+                                            {
+                                                "tag": "EVar",
+                                                "name": "N",
+                                                "sort": {
+                                                    "tag": "SortApp",
+                                                    "name": "SortInt",
+                                                    "args": []
+                                                }
+                                            },
+                                            {
+                                                "tag": "DV",
+                                                "sort": {
+                                                    "tag": "SortApp",
+                                                    "name": "SortInt",
+                                                    "args": []
+                                                },
+                                                "value": "42"
+                                            }
+                                        ]
+                                    },
+                                    "second": {
+                                        "tag": "DV",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortBool",
+                                            "args": []
+                                        },
+                                        "value": "true"
                                     }
                                 },
                                 {
-                                    "tag": "DV",
-                                    "sort": {
+                                    "tag": "Equals",
+                                    "argSort": {
                                         "tag": "SortApp",
-                                        "name": "SortInt",
+                                        "name": "SortBool",
                                         "args": []
                                     },
-                                    "value": "0"
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortGeneratedTopCell",
+                                        "args": []
+                                    },
+                                    "first": {
+                                        "tag": "App",
+                                        "name": "Lbl'UndsEqlsEqls'Int'Unds'",
+                                        "sorts": [],
+                                        "args": [
+                                            {
+                                                "tag": "EVar",
+                                                "name": "N",
+                                                "sort": {
+                                                    "tag": "SortApp",
+                                                    "name": "SortInt",
+                                                    "args": []
+                                                }
+                                            },
+                                            {
+                                                "tag": "DV",
+                                                "sort": {
+                                                    "tag": "SortApp",
+                                                    "name": "SortInt",
+                                                    "args": []
+                                                },
+                                                "value": "0"
+                                            }
+                                        ]
+                                    },
+                                    "second": {
+                                        "tag": "DV",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortBool",
+                                            "args": []
+                                        },
+                                        "value": "true"
+                                    }
                                 }
                             ]
-                        },
-                        "second": {
-                            "tag": "DV",
-                            "sort": {
-                                "tag": "SortApp",
-                                "name": "SortBool",
-                                "args": []
-                            },
-                            "value": "true"
                         }
-                    }
+                    ]
                 }
             }
         }

--- a/test/rpc-integration/test-vacuous/response-vacuous-without-rewrite.json
+++ b/test/rpc-integration/test-vacuous/response-vacuous-without-rewrite.json
@@ -9,169 +9,68 @@
                 "format": "KORE",
                 "version": 1,
                 "term": {
-                    "tag": "App",
-                    "name": "Lbl'-LT-'generatedTop'-GT-'",
-                    "sorts": [],
-                    "args": [
-                        {
-                            "tag": "App",
-                            "name": "Lbl'-LT-'k'-GT-'",
-                            "sorts": [],
-                            "args": [
-                                {
-                                    "tag": "App",
-                                    "name": "kseq",
-                                    "sorts": [],
-                                    "args": [
-                                        {
-                                            "tag": "App",
-                                            "name": "inj",
-                                            "sorts": [
-                                                {
-                                                    "tag": "SortApp",
-                                                    "name": "SortState",
-                                                    "args": []
-                                                },
-                                                {
-                                                    "tag": "SortApp",
-                                                    "name": "SortKItem",
-                                                    "args": []
-                                                }
-                                            ],
-                                            "args": [
-                                                {
-                                                    "tag": "DV",
-                                                    "sort": {
-                                                        "tag": "SortApp",
-                                                        "name": "SortState",
-                                                        "args": []
-                                                    },
-                                                    "value": "d"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "tag": "App",
-                                            "name": "dotk",
-                                            "sorts": [],
-                                            "args": []
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "tag": "App",
-                            "name": "Lbl'-LT-'int'-GT-'",
-                            "sorts": [],
-                            "args": [
-                                {
-                                    "tag": "EVar",
-                                    "name": "N",
-                                    "sort": {
-                                        "tag": "SortApp",
-                                        "name": "SortInt",
-                                        "args": []
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "tag": "App",
-                            "name": "Lbl'-LT-'generatedCounter'-GT-'",
-                            "sorts": [],
-                            "args": [
-                                {
-                                    "tag": "DV",
-                                    "sort": {
-                                        "tag": "SortApp",
-                                        "name": "SortInt",
-                                        "args": []
-                                    },
-                                    "value": "0"
-                                }
-                            ]
-                        }
-                    ]
-                }
-            },
-            "predicate": {
-                "format": "KORE",
-                "version": 1,
-                "term": {
                     "tag": "And",
                     "sort": {
                         "tag": "SortApp",
                         "name": "SortGeneratedTopCell",
                         "args": []
                     },
-                    "first": {
-                        "tag": "Equals",
-                        "argSort": {
-                            "tag": "SortApp",
-                            "name": "SortBool",
-                            "args": []
-                        },
-                        "sort": {
-                            "tag": "SortApp",
-                            "name": "SortGeneratedTopCell",
-                            "args": []
-                        },
-                        "first": {
+                    "patterns": [
+                        {
                             "tag": "App",
-                            "name": "Lbl'UndsEqlsEqls'Int'Unds'",
-                            "sorts": [],
-                            "args": [
-                                {
-                                    "tag": "EVar",
-                                    "name": "N",
-                                    "sort": {
-                                        "tag": "SortApp",
-                                        "name": "SortInt",
-                                        "args": []
-                                    }
-                                },
-                                {
-                                    "tag": "DV",
-                                    "sort": {
-                                        "tag": "SortApp",
-                                        "name": "SortInt",
-                                        "args": []
-                                    },
-                                    "value": "0"
-                                }
-                            ]
-                        },
-                        "second": {
-                            "tag": "DV",
-                            "sort": {
-                                "tag": "SortApp",
-                                "name": "SortBool",
-                                "args": []
-                            },
-                            "value": "true"
-                        }
-                    },
-                    "second": {
-                        "tag": "Equals",
-                        "argSort": {
-                            "tag": "SortApp",
-                            "name": "SortBool",
-                            "args": []
-                        },
-                        "sort": {
-                            "tag": "SortApp",
-                            "name": "SortGeneratedTopCell",
-                            "args": []
-                        },
-                        "first": {
-                            "tag": "App",
-                            "name": "LblnotBool'Unds'",
+                            "name": "Lbl'-LT-'generatedTop'-GT-'",
                             "sorts": [],
                             "args": [
                                 {
                                     "tag": "App",
-                                    "name": "Lbl'UndsEqlsEqls'Int'Unds'",
+                                    "name": "Lbl'-LT-'k'-GT-'",
+                                    "sorts": [],
+                                    "args": [
+                                        {
+                                            "tag": "App",
+                                            "name": "kseq",
+                                            "sorts": [],
+                                            "args": [
+                                                {
+                                                    "tag": "App",
+                                                    "name": "inj",
+                                                    "sorts": [
+                                                        {
+                                                            "tag": "SortApp",
+                                                            "name": "SortState",
+                                                            "args": []
+                                                        },
+                                                        {
+                                                            "tag": "SortApp",
+                                                            "name": "SortKItem",
+                                                            "args": []
+                                                        }
+                                                    ],
+                                                    "args": [
+                                                        {
+                                                            "tag": "DV",
+                                                            "sort": {
+                                                                "tag": "SortApp",
+                                                                "name": "SortState",
+                                                                "args": []
+                                                            },
+                                                            "value": "d"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "tag": "App",
+                                                    "name": "dotk",
+                                                    "sorts": [],
+                                                    "args": []
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "tag": "App",
+                                    "name": "Lbl'-LT-'int'-GT-'",
                                     "sorts": [],
                                     "args": [
                                         {
@@ -182,7 +81,14 @@
                                                 "name": "SortInt",
                                                 "args": []
                                             }
-                                        },
+                                        }
+                                    ]
+                                },
+                                {
+                                    "tag": "App",
+                                    "name": "Lbl'-LT-'generatedCounter'-GT-'",
+                                    "sorts": [],
+                                    "args": [
                                         {
                                             "tag": "DV",
                                             "sort": {
@@ -196,16 +102,118 @@
                                 }
                             ]
                         },
-                        "second": {
-                            "tag": "DV",
+                        {
+                            "tag": "And",
                             "sort": {
                                 "tag": "SortApp",
-                                "name": "SortBool",
+                                "name": "SortGeneratedTopCell",
                                 "args": []
                             },
-                            "value": "true"
+                            "patterns": [
+                                {
+                                    "tag": "Equals",
+                                    "argSort": {
+                                        "tag": "SortApp",
+                                        "name": "SortBool",
+                                        "args": []
+                                    },
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortGeneratedTopCell",
+                                        "args": []
+                                    },
+                                    "first": {
+                                        "tag": "App",
+                                        "name": "Lbl'UndsEqlsEqls'Int'Unds'",
+                                        "sorts": [],
+                                        "args": [
+                                            {
+                                                "tag": "EVar",
+                                                "name": "N",
+                                                "sort": {
+                                                    "tag": "SortApp",
+                                                    "name": "SortInt",
+                                                    "args": []
+                                                }
+                                            },
+                                            {
+                                                "tag": "DV",
+                                                "sort": {
+                                                    "tag": "SortApp",
+                                                    "name": "SortInt",
+                                                    "args": []
+                                                },
+                                                "value": "0"
+                                            }
+                                        ]
+                                    },
+                                    "second": {
+                                        "tag": "DV",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortBool",
+                                            "args": []
+                                        },
+                                        "value": "true"
+                                    }
+                                },
+                                {
+                                    "tag": "Equals",
+                                    "argSort": {
+                                        "tag": "SortApp",
+                                        "name": "SortBool",
+                                        "args": []
+                                    },
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortGeneratedTopCell",
+                                        "args": []
+                                    },
+                                    "first": {
+                                        "tag": "App",
+                                        "name": "LblnotBool'Unds'",
+                                        "sorts": [],
+                                        "args": [
+                                            {
+                                                "tag": "App",
+                                                "name": "Lbl'UndsEqlsEqls'Int'Unds'",
+                                                "sorts": [],
+                                                "args": [
+                                                    {
+                                                        "tag": "EVar",
+                                                        "name": "N",
+                                                        "sort": {
+                                                            "tag": "SortApp",
+                                                            "name": "SortInt",
+                                                            "args": []
+                                                        }
+                                                    },
+                                                    {
+                                                        "tag": "DV",
+                                                        "sort": {
+                                                            "tag": "SortApp",
+                                                            "name": "SortInt",
+                                                            "args": []
+                                                        },
+                                                        "value": "0"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "second": {
+                                        "tag": "DV",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortBool",
+                                            "args": []
+                                        },
+                                        "value": "true"
+                                    }
+                                }
+                            ]
                         }
-                    }
+                    ]
                 }
             }
         }

--- a/tools/booster/Proxy.hs
+++ b/tools/booster/Proxy.hs
@@ -273,7 +273,6 @@ respondEither mbStatsVar forceFallback booster kore req = case req of
                                                 combineLogs
                                                     [ rpcLogs
                                                     , boosterResult.logs
-                                                    , -- , boosterStateSimplificationLogs
                                                       koreResult.logs
                                                     , fallbackLog
                                                     ]

--- a/tools/booster/Proxy.hs
+++ b/tools/booster/Proxy.hs
@@ -235,85 +235,79 @@ respondEither mbStatsVar forceFallback booster kore req = case req of
                 | boosterResult.reason `elem` [Aborted, Stuck, Branching] -> do
                     Log.logInfoNS "proxy" . Text.pack $
                         "Booster " <> show boosterResult.reason <> " at " <> show boosterResult.depth
-                    -- simplify Booster's state with Kore's simplifier
-                    Log.logInfoNS "proxy" . Text.pack $ "Simplifying booster state and falling back to Kore "
-                    simplifyResult <- simplifyExecuteState logSettings r._module boosterResult.state
-                    case simplifyResult of
-                        Left logsOnly -> do
-                            -- state was simplified to \bottom, return vacuous
-                            Log.logInfoNS "proxy" "Vacuous state after simplification"
-                            pure . Right . Execute $ makeVacuous logsOnly boosterResult
-                        Right (simplifiedBoosterState, boosterStateSimplificationLogs) -> do
-                            -- attempt to do one step in the old backend
-                            (kResult, kTime) <-
-                                Stats.timed $
-                                    kore
-                                        ( Execute
-                                            r
-                                                { state = execStateToKoreJson simplifiedBoosterState
-                                                , maxDepth = Just $ Depth 1
-                                                }
-                                        )
-                            when (isJust mbStatsVar) $
-                                Log.logInfoNS "proxy" . Text.pack $
-                                    "Kore fall-back in " <> microsWithUnit kTime
-                            case kResult of
-                                Right (Execute koreResult) -> do
-                                    let
-                                        fallbackLog =
-                                            if fromMaybe False logSettings.logFallbacks
-                                                then Just [mkFallbackLogEntry boosterResult koreResult]
-                                                else Nothing
-                                    case koreResult.reason of
-                                        DepthBound -> do
-                                            -- if we made one step, add the number of
-                                            -- steps we have taken to the counter and
-                                            -- attempt with booster again
-                                            when (koreResult.depth == 0) $ error "Expected kore-rpc to take at least one step"
-                                            Log.logInfoNS "proxy" $
-                                                Text.pack $
-                                                    "kore depth-bound, continuing... (currently at "
-                                                        <> show (currentDepth + boosterResult.depth + koreResult.depth)
-                                                        <> ")"
-                                            let accumulatedLogs =
-                                                    combineLogs
-                                                        [ rpcLogs
-                                                        , boosterResult.logs
-                                                        , boosterStateSimplificationLogs
-                                                        , koreResult.logs
-                                                        , fallbackLog
-                                                        ]
-                                            executionLoop
-                                                logSettings
-                                                mforceSimplification
-                                                ( currentDepth + boosterResult.depth + koreResult.depth
-                                                , time + bTime + kTime
-                                                , koreTime + kTime
-                                                , accumulatedLogs
-                                                )
-                                                r{ExecuteRequest.state = execStateToKoreJson koreResult.state}
-                                        _ -> do
-                                            -- otherwise we have hit a different
-                                            -- HaltReason, at which point we should
-                                            -- return, setting the correct depth
-                                            Log.logInfoNS "proxy" . Text.pack $
-                                                "Kore " <> show koreResult.reason <> " at " <> show koreResult.depth
-                                            logStats ExecuteM (time + bTime + kTime, koreTime + kTime)
-                                            pure $
-                                                Right $
-                                                    Execute
-                                                        koreResult
-                                                            { depth = currentDepth + boosterResult.depth + koreResult.depth
-                                                            , logs =
-                                                                combineLogs
-                                                                    [ rpcLogs
-                                                                    , boosterResult.logs
-                                                                    , koreResult.logs
-                                                                    , fallbackLog
-                                                                    ]
-                                                            }
-                                -- can only be an error at this point
-                                res -> pure res
+                    -- re-execute with kore-rpc (no need to simplify first, kore-rpc will do that)
+                    Log.logInfoNS "proxy" . Text.pack $ "Falling back to Kore "
+                    -- attempt to do one step in the old backend
+                    (kResult, kTime) <-
+                        Stats.timed $
+                            kore
+                                ( Execute
+                                    r
+                                        { state = execStateToKoreJson boosterResult.state
+                                        , maxDepth = Just $ Depth 1
+                                        }
+                                )
+                    do
+                        when (isJust mbStatsVar) $
+                            Log.logInfoNS "proxy" . Text.pack $
+                                "Kore fall-back in " <> microsWithUnit kTime
+                        case kResult of
+                            Right (Execute koreResult) -> do
+                                let
+                                    fallbackLog =
+                                        if fromMaybe False logSettings.logFallbacks
+                                            then Just [mkFallbackLogEntry boosterResult koreResult]
+                                            else Nothing
+                                case koreResult.reason of
+                                    DepthBound -> do
+                                        -- if we made one step, add the number of
+                                        -- steps we have taken to the counter and
+                                        -- attempt with booster again
+                                        when (koreResult.depth == 0) $ error "Expected kore-rpc to take at least one step"
+                                        Log.logInfoNS "proxy" $
+                                            Text.pack $
+                                                "kore depth-bound, continuing... (currently at "
+                                                    <> show (currentDepth + boosterResult.depth + koreResult.depth)
+                                                    <> ")"
+                                        let accumulatedLogs =
+                                                combineLogs
+                                                    [ rpcLogs
+                                                    , boosterResult.logs
+                                                    , -- , boosterStateSimplificationLogs
+                                                      koreResult.logs
+                                                    , fallbackLog
+                                                    ]
+                                        executionLoop
+                                            logSettings
+                                            mforceSimplification
+                                            ( currentDepth + boosterResult.depth + koreResult.depth
+                                            , time + bTime + kTime
+                                            , koreTime + kTime
+                                            , accumulatedLogs
+                                            )
+                                            r{ExecuteRequest.state = execStateToKoreJson koreResult.state}
+                                    _ -> do
+                                        -- otherwise we have hit a different
+                                        -- HaltReason, at which point we should
+                                        -- return, setting the correct depth
+                                        Log.logInfoNS "proxy" . Text.pack $
+                                            "Kore " <> show koreResult.reason <> " at " <> show koreResult.depth
+                                        logStats ExecuteM (time + bTime + kTime, koreTime + kTime)
+                                        pure $
+                                            Right $
+                                                Execute
+                                                    koreResult
+                                                        { depth = currentDepth + boosterResult.depth + koreResult.depth
+                                                        , logs =
+                                                            combineLogs
+                                                                [ rpcLogs
+                                                                , boosterResult.logs
+                                                                , koreResult.logs
+                                                                , fallbackLog
+                                                                ]
+                                                        }
+                            -- can only be an error at this point
+                            res -> pure res
                 | otherwise -> do
                     -- we were successful with the booster, thus we
                     -- return the booster result with the updated

--- a/tools/booster/Proxy.hs
+++ b/tools/booster/Proxy.hs
@@ -273,7 +273,7 @@ respondEither mbStatsVar forceFallback booster kore req = case req of
                                                 combineLogs
                                                     [ rpcLogs
                                                     , boosterResult.logs
-                                                      koreResult.logs
+                                                    , koreResult.logs
                                                     , fallbackLog
                                                     ]
                                         executionLoop


### PR DESCRIPTION
When an execute request ends with an `Aborted`, `Stuck`, or `Branching` reason, it is usually re-executed with legacy `kore-rpc`. As part of that, the simplifier will run on the input.

However, we are _also_ explicitly simplifying the end state of the execute request (and return `Vacuous` if it simplifies to `\bottom`). This additional work is unnecessary as we will anyway get the `\bottom` result back from `kore-rpc` (alas, in a slightly different shape).

This saves one round of fall-back to `kore-rpc` and should speed up long-running proofs that have to fall back often due to side condition checking.