### PR TITLE
Cleanup predicate simplifier code

### DIFF
--- a/library/Booster/JsonRpc.hs
+++ b/library/Booster/JsonRpc.hs
@@ -182,7 +182,7 @@ respond stateVar =
                                     [] -> term
                                     ps -> KoreJson.KJAnd tSort $ term : ps
                             pure $ Right (addHeader result, patternTraces)
-                        (Left ApplyEquations.SideConditionsFalse{}, patternTraces, _) -> do
+                        (Left ApplyEquations.SideConditionFalse{}, patternTraces, _) -> do
                             let tSort = fromMaybe (error "unknown sort") $ sortOfJson req.state.term
                             pure $ Right (addHeader $ KoreJson.KJBottom tSort, patternTraces)
                         (Left (ApplyEquations.EquationLoop terms), _traces, _) ->
@@ -441,7 +441,7 @@ mkLogEquationTrace
                             , origin
                             , result = Failure{reason = "Indeterminate side-condition", _ruleId}
                             }
-            ApplyEquations.ConditionFalse
+            ApplyEquations.ConditionFalse{}
                 | logFailedSimplifications ->
                     Just $
                         Simplification
@@ -573,7 +573,7 @@ mkLogRewriteTrace
                                     , origin = Booster
                                     , result = Failure{reason = "Internal error: " <> err, _ruleId = Nothing}
                                     }
-                            ApplyEquations.SideConditionsFalse _predicates ->
+                            ApplyEquations.SideConditionFalse _predicate ->
                                 Simplification
                                     { originalTerm = Nothing
                                     , originalTermIndex = Nothing

--- a/library/Booster/Pattern/Rewrite.hs
+++ b/library/Booster/Pattern/Rewrite.hs
@@ -605,8 +605,8 @@ performRewrite doTracing def mLlvmLibrary mbMaxDepth cutLabels terminalLabels pa
                 Right newPattern -> do
                     rewriteTrace $ RewriteSimplified traces Nothing
                     pure $ Just newPattern
-                Left r@(SideConditionsFalse _ps) -> do
-                    logSimplify "Side conditions were found to be false, pruning"
+                Left r@(SideConditionFalse _p) -> do
+                    logSimplify "A side condition was found to be false, pruning"
                     rewriteTrace $ RewriteSimplified traces (Just r)
                     pure Nothing
                 -- NB any errors here might be caused by simplifying one

--- a/library/Booster/Pattern/Simplify.hs
+++ b/library/Booster/Pattern/Simplify.hs
@@ -3,17 +3,11 @@ Copyright   : (c) Runtime Verification, 2022
 License     : BSD-3-Clause
 -}
 module Booster.Pattern.Simplify (
-    simplifyPredicate,
     splitBoolPredicates,
-    simplifyConcrete,
 ) where
 
-import Booster.Definition.Base
-import Booster.LLVM (simplifyBool, simplifyTerm)
-import Booster.LLVM.Internal qualified as LLVM
 import Booster.Pattern.Base
-import Booster.Pattern.Util (isConcrete, sortOfTerm)
-import Data.Bifunctor (bimap)
+import Booster.Pattern.Util (isConcrete)
 
 {- | We want to break apart predicates of type `X #Equals Y1 andBool ... Yn` into
 `X #Equals Y1, ..., X #Equals  Yn` in the case when some of the `Y`s are abstract
@@ -25,68 +19,3 @@ splitBoolPredicates = \case
     EqualsTerm (AndBool ls) r -> concatMap (splitBoolPredicates . flip EqualsTerm r) ls
     EqualsTerm l (AndBool rs) -> concatMap (splitBoolPredicates . EqualsTerm l) rs
     other -> [other]
-
-simplifyPredicate :: Maybe LLVM.API -> Predicate -> Predicate
-simplifyPredicate mApi = \case
-    AndPredicate l r -> case (simplifyPredicate mApi l, simplifyPredicate mApi r) of
-        (Bottom, _) -> Bottom
-        (_, Bottom) -> Bottom
-        (Top, r') -> r'
-        (l', Top) -> l'
-        (l', r') -> AndPredicate l' r'
-    Bottom -> Bottom
-    p@(Ceil _) -> p
-    p@(EqualsTerm l r) ->
-        case (mApi, sortOfTerm l == SortBool && isConcrete l && isConcrete r) of
-            (Just api, True) ->
-                if simplifyBool api l == simplifyBool api r
-                    then Top
-                    else Bottom
-            _ -> p
-    EqualsPredicate l r -> EqualsPredicate (simplifyPredicate mApi l) (simplifyPredicate mApi r)
-    p@(Exists _ _) -> p
-    p@(Forall _ _) -> p
-    Iff l r -> Iff (simplifyPredicate mApi l) (simplifyPredicate mApi r)
-    Implies l r -> Implies (simplifyPredicate mApi l) (simplifyPredicate mApi r)
-    p@(In _ _) -> p
-    Not p -> case simplifyPredicate mApi p of
-        Top -> Bottom
-        Bottom -> Top
-        p' -> p'
-    Or l r -> Or (simplifyPredicate mApi l) (simplifyPredicate mApi r)
-    Top -> Top
-
-{- | traverses a term top-down, using a given LLVM dy.lib to simplify
- the concrete parts (leaving variables alone)
--}
-simplifyConcrete :: Maybe LLVM.API -> KoreDefinition -> Term -> Term
-simplifyConcrete Nothing _ trm = trm
-simplifyConcrete (Just mApi) def trm = recurse trm
-  where
-    recurse :: Term -> Term
-    -- recursion scheme for this?
-    --     cata $ \case does not work here, would need helpers for TermF not Term
-    --         t | isConcreteF t -> simplifyTerm dl def t (sortOfTerm t)
-    --         other -> embed other\
-    recurse t@(Term attributes _)
-        | attributes.isEvaluated =
-            t
-        | isConcrete t && attributes.canBeEvaluated =
-            simplifyTerm mApi def t (sortOfTerm t)
-        | otherwise =
-            case t of
-                var@Var{} ->
-                    var -- nothing to do. Should have isEvaluated set
-                dv@DomainValue{} ->
-                    dv -- nothing to do. Should have isEvaluated set
-                AndTerm t1 t2 ->
-                    AndTerm (recurse t1) (recurse t2)
-                SymbolApplication sym sorts args ->
-                    SymbolApplication sym sorts (map recurse args)
-                Injection sources target sub ->
-                    Injection sources target $ recurse sub
-                KMap mdef keyVals rest -> KMap mdef (map (bimap recurse recurse) keyVals) (recurse <$> rest)
-                KList ldef heads rest ->
-                    KList ldef (map recurse heads) (fmap (bimap recurse (map recurse)) rest)
-                KSet sdef heads rest ->
-                    KSet sdef (map recurse heads) (fmap recurse rest)


### PR DESCRIPTION
We currently have two code paths for predicate simplification. This is messy and confusing. This PR refactors this into a single code-path parametrized on whether we want to recurse into equation application or not.