### PR TITLE
Patch stacklock2nix to download all refs when fetching git package deps

### DIFF
--- a/stacklock2nix.patch
+++ b/stacklock2nix.patch
@@ -1,0 +1,12 @@
+diff --git a/nix/build-support/stacklock2nix/default.nix b/nix/build-support/stacklock2nix/default.nix
+index b13f246..116ca11 100644
+--- a/nix/build-support/stacklock2nix/default.nix
++++ b/nix/build-support/stacklock2nix/default.nix
+@@ -380,6 +380,7 @@ let
+             url = haskPkgLock.git;
+             name = srcName;
+             rev = haskPkgLock.commit;
++            allRefs = true;
+           };
+           src =
+             if haskPkgLock ? "subdir" then


### PR DESCRIPTION
Temporary fix for https://github.com/cdepillabout/stacklock2nix/issues/38, until this is (hopefully) fixed upstream