### PR TITLE
Fix incorrect KMap injections, received from the LLVM library

### DIFF
--- a/test/llvm-integration/LLVM.hs
+++ b/test/llvm-integration/LLVM.hs
@@ -152,7 +152,6 @@ latin1Prop api = property $ do
                 | otherwise -> error $ "Unexpected sort " <> show s
             otherTerm -> error $ "Unexpected term " <> show otherTerm
 
-
 mapKItemInjProp :: Internal.API -> Property
 mapKItemInjProp api = property $ do
     let k = wrapIntTerm 1
@@ -179,12 +178,15 @@ mapKItemInjProp api = property $ do
 
     wrapIntTerm :: Int -> Term
     wrapIntTerm i =
-        SymbolApplication (defSymbols Map.! "inj") [SortApp "SortWrappedInt" [], SortApp "SortVal" []] [
-            SymbolApplication
+        SymbolApplication
+            (defSymbols Map.! "inj")
+            [SortApp "SortWrappedInt" [], SortApp "SortVal" []]
+            [ SymbolApplication
                 (defSymbols Map.! "LblwrapInt")
                 []
                 [intTerm i]
             ]
+
 ------------------------------------------------------------
 
 runKompile :: IO ()
@@ -3510,14 +3512,18 @@ defSymbols =
             )
         ,
             ( "LblwrapInt"
-            , [symb| symbol LblwrapInt{}(SortInt{}) : SortWrappedInt{} [constructor{}(), functional{}(), injective{}()] |] )
+            , [symb| symbol LblwrapInt{}(SortInt{}) : SortWrappedInt{} [constructor{}(), functional{}(), injective{}()] |]
+            )
         ,
             ( "Lbl'Stop'MapValToVal"
-            , [symb| symbol Lbl'Stop'MapValToVal{}() : SortMapValToVal{} [function{}(), functional{}(), total{}()] |] )
+            , [symb| symbol Lbl'Stop'MapValToVal{}() : SortMapValToVal{} [function{}(), functional{}(), total{}()] |]
+            )
         ,
             ( "LblMapValToVal'Coln'primitiveUpdate"
-            , [symb| symbol LblMapValToVal'Coln'primitiveUpdate{}(SortMapValToVal{}, SortVal{}, SortVal{}) : SortMapValToVal{} [function{}(), functional{}(), klabel{}("MapValToVal:primitiveUpdate"), total{}()] |])
+            , [symb| symbol LblMapValToVal'Coln'primitiveUpdate{}(SortMapValToVal{}, SortVal{}, SortVal{}) : SortMapValToVal{} [function{}(), functional{}(), klabel{}("MapValToVal:primitiveUpdate"), total{}()] |]
+            )
         ,
             ( "Lbl'Unds'Val2Val'Pipe'-'-GT-Unds'"
-            , [symb| symbol Lbl'Unds'Val2Val'Pipe'-'-GT-Unds'{}(SortVal{}, SortVal{}) : SortMapValToVal{} [function{}(), functional{}(), klabel{}("_Val2Val|->_"), total{}()] |] )
+            , [symb| symbol Lbl'Unds'Val2Val'Pipe'-'-GT-Unds'{}(SortVal{}, SortVal{}) : SortMapValToVal{} [function{}(), functional{}(), klabel{}("_Val2Val|->_"), total{}()] |]
+            )
         ]

--- a/test/llvm-integration/LLVM.hs
+++ b/test/llvm-integration/LLVM.hs
@@ -93,7 +93,7 @@ llvmSpec =
 
         beforeAll loadAPI $
             it "should correct sort injections in non KItem maps" $
-                    hedgehog . propertyTest . mapKItemInjProp
+                hedgehog . propertyTest . mapKItemInjProp
 
 --------------------------------------------------
 -- individual hedgehog property tests and helpers

--- a/test/llvm-integration/LLVM.hs
+++ b/test/llvm-integration/LLVM.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE QuasiQuotes #-}
 
 {- |
 Copyright   : (c) Runtime Verification, 2023
@@ -41,7 +42,7 @@ import Booster.Pattern.Base
 import Booster.Syntax.Json.Externalise (externaliseTerm)
 import Booster.Syntax.Json.Internalise (pattern AllowAlias, pattern IgnoreSubsorts)
 import Booster.Syntax.Json.Internalise qualified as Syntax
-import Booster.Syntax.ParsedKore.Internalise (buildDefinitions)
+import Booster.Syntax.ParsedKore.Internalise (buildDefinitions, symb)
 import Booster.Syntax.ParsedKore.Parser (parseDefinition)
 import Kore.Syntax.Json.Types qualified as Syntax
 import System.Info (os)
@@ -89,6 +90,10 @@ llvmSpec =
             describe "LLVM String handling" $
                 it "should work with latin-1strings" $
                     hedgehog . propertyTest . latin1Prop
+
+            describe "Correct sort injections in non KItem maps" $
+                it "should work with latin-1strings" $
+                    hedgehog . propertyTest . mapKItemInjProp
 
 --------------------------------------------------
 -- individual hedgehog property tests and helpers
@@ -147,6 +152,39 @@ latin1Prop api = property $ do
                 | otherwise -> error $ "Unexpected sort " <> show s
             otherTerm -> error $ "Unexpected term " <> show otherTerm
 
+
+mapKItemInjProp :: Internal.API -> Property
+mapKItemInjProp api = property $ do
+    let k = wrapIntTerm 1
+    let v = wrapIntTerm 2
+    LLVM.simplifyTerm api testDef (update k v) (SortApp "SortMapValToVal" []) === singleton k v
+  where
+    update k v =
+        SymbolApplication
+            (defSymbols Map.! "LblMapValToVal'Coln'primitiveUpdate")
+            []
+            [ SymbolApplication
+                (defSymbols Map.! "Lbl'Stop'MapValToVal")
+                []
+                []
+            , k
+            , v
+            ]
+
+    singleton k v =
+        SymbolApplication
+            (defSymbols Map.! "Lbl'Unds'Val2Val'Pipe'-'-GT-Unds'")
+            []
+            [k, v]
+
+    wrapIntTerm :: Int -> Term
+    wrapIntTerm i =
+        SymbolApplication (defSymbols Map.! "inj") [SortApp "SortWrappedInt" [], SortApp "SortVal" []] [
+            SymbolApplication
+                (defSymbols Map.! "LblwrapInt")
+                []
+                [intTerm i]
+            ]
 ------------------------------------------------------------
 
 runKompile :: IO ()
@@ -3470,4 +3508,16 @@ defSymbols =
                         }
                 }
             )
+        ,
+            ( "LblwrapInt"
+            , [symb| symbol LblwrapInt{}(SortInt{}) : SortWrappedInt{} [constructor{}(), functional{}(), injective{}()] |] )
+        ,
+            ( "Lbl'Stop'MapValToVal"
+            , [symb| symbol Lbl'Stop'MapValToVal{}() : SortMapValToVal{} [function{}(), functional{}(), total{}()] |] )
+        ,
+            ( "LblMapValToVal'Coln'primitiveUpdate"
+            , [symb| symbol LblMapValToVal'Coln'primitiveUpdate{}(SortMapValToVal{}, SortVal{}, SortVal{}) : SortMapValToVal{} [function{}(), functional{}(), klabel{}("MapValToVal:primitiveUpdate"), total{}()] |])
+        ,
+            ( "Lbl'Unds'Val2Val'Pipe'-'-GT-Unds'"
+            , [symb| symbol Lbl'Unds'Val2Val'Pipe'-'-GT-Unds'{}(SortVal{}, SortVal{}) : SortMapValToVal{} [function{}(), functional{}(), klabel{}("_Val2Val|->_"), total{}()] |] )
         ]

--- a/test/llvm-integration/LLVM.hs
+++ b/test/llvm-integration/LLVM.hs
@@ -91,8 +91,8 @@ llvmSpec =
                 it "should work with latin-1strings" $
                     hedgehog . propertyTest . latin1Prop
 
-            describe "Correct sort injections in non KItem maps" $
-                it "should work with latin-1strings" $
+        beforeAll loadAPI $
+            it "should correct sort injections in non KItem maps" $
                     hedgehog . propertyTest . mapKItemInjProp
 
 --------------------------------------------------

--- a/test/llvm-integration/definition/llvm.k
+++ b/test/llvm-integration/definition/llvm.k
@@ -5,6 +5,7 @@ module LLVM
   imports MAP
   imports SET
   imports K-EQUAL
+  imports MAP-VAL-TO-VAL
 
   syntax Num ::= Even | Odd
   syntax Even ::= Zero() | Two() | Four() | Six() | Eight() | Ten()
@@ -39,3 +40,45 @@ module LLVM
   rule div2(Ten()) => Five()
 
 endmodule
+
+module MAP-VAL-TO-VAL
+  imports WRAPPED-INT
+
+  syntax Val ::= WrappedInt
+ // -----------------------
+
+  syntax MapValToVal [hook(MAP.Map)]
+  syntax MapValToVal ::= MapValToVal MapValToVal
+         [ left, function, hook(MAP.concat), klabel(_MapValToVal_),
+           symbol, assoc, comm, unit(.MapValToVal), element(_Val2Val|->_)
+         ]
+  syntax MapValToVal ::= ".MapValToVal"
+         [function, total, hook(MAP.unit),klabel(.MapValToVal), symbol]
+  syntax MapValToVal ::= Val "Val2Val|->" Val
+         [function, total, hook(MAP.element), klabel(_Val2Val|->_), symbol]
+
+  syntax MapValToVal ::= MapValToVal "[" key: Val "<-" value: Val "]" [function, total, klabel(MapVal2Val:update), symbol, hook(MAP.update), prefer]
+
+  syntax priorities _Val2Val|->_ > _MapValToVal_ .MapValToVal
+  syntax non-assoc _Val2Val|->_
+
+  syntax MapValToVal ::= MapValToVal "{{" key: Val "<-" value: Val "}}"
+                 [ function, total, klabel(MapValToVal:primitiveUpdate), symbol,
+                   prefer
+                 ]
+  rule M:MapValToVal {{ Key:Val <- Value:Val }}
+      => M[Key <- Value]
+
+endmodule
+
+module WRAPPED-INT
+  imports INT
+
+  syntax WrappedInt ::= wrap(Int)  [symbol, klabel(wrapInt)]
+  // -------------------------------------------------------
+
+  syntax Int ::= unwrap(WrappedInt)  [function, total, injective, symbol, klabel(unwrapInt)]
+  // ---------------------------------------------------------------------------------------
+  rule unwrap(wrap(A:Int)) => A
+endmodule
+


### PR DESCRIPTION
This is a temporary fix for #321 until properly addressed upstream by https://github.com/runtimeverification/llvm-backend/issues/886 . The fix involves manually adjusting an injection to the correct sort, since we know the sort of the argument for a given symbol from the `KoreDefintion`, passed to the decoder.