### PR TITLE
Fix internalisation of KJAnd predicates in the simplify endpoint

### DIFF
--- a/library/Booster/Pattern/ApplyEquations.hs
+++ b/library/Booster/Pattern/ApplyEquations.hs
@@ -13,6 +13,7 @@ module Booster.Pattern.ApplyEquations (
     isMatchFailure,
     isSuccess,
     simplifyConstraint,
+    simplifyConstraints,
     SimplifierCache,
 ) where
 
@@ -674,6 +675,17 @@ simplifyConstraint ::
     io (Either EquationFailure Predicate, [EquationTrace], SimplifierCache)
 simplifyConstraint doTracing def mbApi cache p =
     runEquationT doTracing def mbApi cache $ simplifyConstraint' True p
+
+simplifyConstraints ::
+    MonadLoggerIO io =>
+    Bool ->
+    KoreDefinition ->
+    Maybe LLVM.API ->
+    SimplifierCache ->
+    [Predicate] ->
+    io (Either EquationFailure [Predicate], [EquationTrace], SimplifierCache)
+simplifyConstraints doTracing def mbApi cache ps =
+    runEquationT doTracing def mbApi cache $ mapM (simplifyConstraint' True) ps
 
 -- version for internal nested evaluation
 simplifyConstraint' :: MonadLoggerIO io => Bool -> Predicate -> EquationT io Predicate

--- a/library/Booster/Pattern/Base.hs
+++ b/library/Booster/Pattern/Base.hs
@@ -821,8 +821,8 @@ data InternalisedPredicate = IsPredicate Predicate | IsCeil Ceil | IsSubstitutio
     deriving stock (Eq, Ord, Show, Generic)
     deriving anyclass (NFData)
 
-data TermOrPredicate -- = Either Predicate Pattern
-    = BoolOrCeilOrSubstitutionPredicate InternalisedPredicate
+data TermOrPredicates -- = Either Predicate Pattern
+    = BoolOrCeilOrSubstitutionPredicates !(Set Predicate) ![Ceil] (Map Variable Term)
     | TermAndPredicateAndSubstitution Pattern (Map Variable Term)
     deriving stock (Eq, Ord, Show, Generic)
     deriving anyclass (NFData)
@@ -969,3 +969,4 @@ instance Pretty Pattern where
             , "Conditions:"
             ]
                 <> fmap (Pretty.indent 4 . pretty) (Set.toList patt.constraints)
+                <> fmap (Pretty.indent 4 . pretty) patt.ceilConditions

--- a/library/Booster/Pattern/Util.hs
+++ b/library/Booster/Pattern/Util.hs
@@ -78,7 +78,7 @@ applySubst subst (SortApp n args) =
 
 sortOfTermOrPredicate :: TermOrPredicates -> Maybe Sort
 sortOfTermOrPredicate (TermAndPredicateAndSubstitution Pattern{term} _) = Just (sortOfTerm term)
-sortOfTermOrPredicate BoolOrCeilOrSubstitutionPredicates {} = Nothing
+sortOfTermOrPredicate BoolOrCeilOrSubstitutionPredicates{} = Nothing
 
 sortOfPattern :: Pattern -> Sort
 sortOfPattern pat = sortOfTerm pat.term

--- a/library/Booster/Pattern/Util.hs
+++ b/library/Booster/Pattern/Util.hs
@@ -32,6 +32,7 @@ module Booster.Pattern.Util (
     abstractSymbolicConstructorArguments,
     cellSymbolStats,
     cellVariableStats,
+    partitionInternalised,
 ) where
 
 import Data.Bifunctor (bimap, first)
@@ -75,14 +76,14 @@ applySubst subst var@(SortVar n) =
 applySubst subst (SortApp n args) =
     SortApp n $ map (applySubst subst) args
 
-sortOfTermOrPredicate :: TermOrPredicate -> Maybe Sort
+sortOfTermOrPredicate :: TermOrPredicates -> Maybe Sort
 sortOfTermOrPredicate (TermAndPredicateAndSubstitution Pattern{term} _) = Just (sortOfTerm term)
-sortOfTermOrPredicate (BoolOrCeilOrSubstitutionPredicate _) = Nothing
+sortOfTermOrPredicate (BoolOrCeilOrSubstitutionPredicates _ _ _) = Nothing
 
 sortOfPattern :: Pattern -> Sort
 sortOfPattern pat = sortOfTerm pat.term
 
-retractPattern :: TermOrPredicate -> Maybe Pattern
+retractPattern :: TermOrPredicates -> Maybe Pattern
 retractPattern (TermAndPredicateAndSubstitution patt _) = Just patt
 retractPattern _ = Nothing
 
@@ -376,3 +377,15 @@ cellVariableStats name = go
         KMap{} -> Map.empty
         KList{} -> Map.empty
         KSet{} -> Map.empty
+
+partitionInternalised ::
+    [InternalisedPredicate] ->
+    (Set Predicate, [Ceil], Map Variable Term)
+partitionInternalised =
+    foldr
+        ( \r (preds, ceils, subs) -> case r of
+            IsPredicate pr -> (Set.insert pr preds, ceils, subs)
+            IsCeil c -> (preds, c : ceils, subs)
+            IsSubstitution k v -> (preds, ceils, Map.insert k v subs)
+        )
+        mempty

--- a/library/Booster/Pattern/Util.hs
+++ b/library/Booster/Pattern/Util.hs
@@ -78,7 +78,7 @@ applySubst subst (SortApp n args) =
 
 sortOfTermOrPredicate :: TermOrPredicates -> Maybe Sort
 sortOfTermOrPredicate (TermAndPredicateAndSubstitution Pattern{term} _) = Just (sortOfTerm term)
-sortOfTermOrPredicate (BoolOrCeilOrSubstitutionPredicates _ _ _) = Nothing
+sortOfTermOrPredicate BoolOrCeilOrSubstitutionPredicates {} = Nothing
 
 sortOfPattern :: Pattern -> Sort
 sortOfPattern pat = sortOfTerm pat.term

--- a/library/Booster/Syntax/Json/Externalise.hs
+++ b/library/Booster/Syntax/Json/Externalise.hs
@@ -5,6 +5,8 @@ License     : BSD-3-Clause
 module Booster.Syntax.Json.Externalise (
     externalisePattern,
     externalisePredicate,
+    externaliseCeil,
+    externaliseSubstitution,
     externaliseSort,
     externaliseTerm,
 ) where

--- a/library/Booster/Syntax/ParsedKore/Internalise.hs
+++ b/library/Booster/Syntax/ParsedKore/Internalise.hs
@@ -872,7 +872,7 @@ internaliseRewriteRule partialDefinition exs aliasName aliasArgs right axAttribu
         unless (null substitution) $ throwE $ DefinitionPatternError ref SubstitutionNotAllowed
         pure $ removeTrueBools $ Util.modifyVariables f pat
 
-expandAlias :: Alias -> [Def.Term] -> Except DefinitionError Def.TermOrPredicate
+expandAlias :: Alias -> [Def.Term] -> Except DefinitionError Def.TermOrPredicates
 expandAlias alias currentArgs
     | length alias.args /= length currentArgs =
         throwE $
@@ -1265,7 +1265,7 @@ instance Pretty AxiomError where
                 runExcept (Attributes.readLocation rule.attributes)
 
 newtype TermOrPredicateError
-    = PatternExpected Def.TermOrPredicate
+    = PatternExpected Def.TermOrPredicates
     deriving stock (Eq, Show)
 
 symb :: QuasiQuoter


### PR DESCRIPTION
Fixes #380 by using `explodeAnd` in the first alternative of `internaliseTermOrPredicate`