### PR TITLE
Improve parsing of performance test logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ result*
 /test/rpc-integration/resources/*.dylib
 .DS_Store
 /*.code-workspace
+/scripts/logs

--- a/scripts/compare.py
+++ b/scripts/compare.py
@@ -14,7 +14,7 @@ if len(sys.argv) > 4:
 else:
     minchange = 0.035
 
-testname = re.compile(r'^src/.*\[(?P<name>.*)\]$')
+testname = re.compile(r'.*\[(?P<name>.*)\]$')
 
 def readName(input):
     r = testname.match(input)
@@ -27,23 +27,36 @@ def readData(file_name):
     data_lines = []
     with open(file_name, 'r') as file_data:
         for line in file_data:
-            data_line = [l for l in line.strip('\n').split(' ') if l != '']
-            if data_line[1] == 'call':
+            if ' call     ' in line:
+                data_line = [l for l in line.strip('\n').split(' ') if l != '']
                 time = float(data_line[0][:-1])
                 test = readName(data_line[2])
                 if time > 0.5:
                     data_lines.append((test, time))
     return data_lines
 
-def getKey(file_name):
-    return file_name.split('.')[-1]
+def longestCommonPrefix(my_str):
+    if not my_str:
+        return ''
+    prefix = my_str[0]
+    for word in my_str:
+        if len(prefix) > len(word):
+            prefix, word = word, prefix
+        while len(prefix) > 0:
+            if word[:len(prefix)] == prefix:
+                break
+            else:
+                prefix = prefix[:-1]
+    return prefix
+
+def getKeys(file_name1, file_name2):
+    prefix = longestCommonPrefix([file_name1, file_name2])
+    return file_name1[len(prefix):].rstrip(".log"), file_name2[len(prefix):].rstrip(".log")
 
 data_entries = {}
-key1 = getKey(logfile_1)
+key1, key2 = getKeys(logfile_1, logfile_2)
 data_entries[key1] = { test : time for (test, time) in readData(logfile_1) }
-key2 = getKey(logfile_2)
 data_entries[key2] = { test : time for (test, time) in readData(logfile_2) }
-
 common_passing_tests = [k1 for k1 in data_entries[key1] if k1 in data_entries[key2]]
 
 def filterEntries(test, t1, t2):

--- a/scripts/performance-tests-kevm.sh
+++ b/scripts/performance-tests-kevm.sh
@@ -10,6 +10,7 @@ KEVM_VERSION=${KEVM_VERSION:-'master'}
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
 MASTER_COMMIT="$(git rev-parse origin/main)"
+MASTER_COMMIT_SHORT="$(git rev-parse --short origin/main)"
 
 FEATURE_BRANCH_NAME=${FEATURE_BRANCH_NAME:-"$(git rev-parse --abbrev-ref HEAD)"}
 FEATURE_BRANCH_NAME="${FEATURE_BRANCH_NAME//\//-}"
@@ -54,12 +55,10 @@ feature_shell "make poetry && poetry run -C kevm-pyk -- kevm-dist --verbose buil
 feature_shell "make test-prove-pyk PYTEST_PARALLEL=$PYTEST_PARALLEL PYTEST_ARGS='--maxfail=0 --timeout 7200 -vv --use-booster' | tee $SCRIPT_DIR/kevm-$KEVM_VERSION-$FEATURE_BRANCH_NAME.log"
 killall kore-rpc-booster || echo "No zombie processes found"
 
-if [ ! -e "$SCRIPT_DIR/kevm-$KEVM_VERSION-master-$MASTER_COMMIT.log" ]; then
-  master_shell "make test-prove-pyk PYTEST_PARALLEL=$PYTEST_PARALLEL PYTEST_ARGS='--maxfail=0 --timeout 7200 -vv --use-booster' | tee $SCRIPT_DIR/kevm-$KEVM_VERSION-master-$MASTER_COMMIT.log"
+if [ ! -e "$SCRIPT_DIR/kevm-$KEVM_VERSION-master-$MASTER_COMMIT_SHORT.log" ]; then
+  master_shell "make test-prove-pyk PYTEST_PARALLEL=$PYTEST_PARALLEL PYTEST_ARGS='--maxfail=0 --timeout 7200 -vv --use-booster' | tee $SCRIPT_DIR/kevm-$KEVM_VERSION-master-$MASTER_COMMIT_SHORT.log"
   killall kore-rpc-booster || echo "No zombie processes found"
 fi
 
 cd $SCRIPT_DIR
-grep ' call  ' kevm-$KEVM_VERSION-$FEATURE_BRANCH_NAME.log > kevm-$KEVM_VERSION-master-$MASTER_COMMIT.$FEATURE_BRANCH_NAME
-grep ' call  ' kevm-$KEVM_VERSION-master-$MASTER_COMMIT.log > kevm-$KEVM_VERSION-master-$MASTER_COMMIT.master
-python3 compare.py kevm-$KEVM_VERSION-master-$MASTER_COMMIT.$FEATURE_BRANCH_NAME kevm-$KEVM_VERSION-master-$MASTER_COMMIT.master > kevm-$KEVM_VERSION-master-$MASTER_COMMIT-$FEATURE_BRANCH_NAME-compare
+python3 compare.py kevm-$KEVM_VERSION-$FEATURE_BRANCH_NAME.log kevm-$KEVM_VERSION-master-$MASTER_COMMIT_SHORT.log > kevm-$KEVM_VERSION-master-$MASTER_COMMIT_SHORT-$FEATURE_BRANCH_NAME-compare

--- a/scripts/performance-tests-kontrol.sh
+++ b/scripts/performance-tests-kontrol.sh
@@ -68,7 +68,7 @@ master_shell() {
   GC_DONT_GC=1 nix develop github:runtimeverification/evm-semantics/$KEVM_VERSION --extra-experimental-features 'nix-command flakes' --override-input k-framework/booster-backend github:runtimeverification/hs-backend-booster/$MASTER_COMMIT --command bash -c "$1"
 }
 
-feature_shell "poetry install && poetry run kevm-dist --verbose build plugin haskell foundry --jobs 4"
+feature_shell "poetry install && poetry run kevm-dist --verbose build evm-semantics.plugin evm-semantics.haskell kontrol.foundry --jobs 4"
 
 mkdir -p $SCRIPT_DIR/logs
 

--- a/scripts/performance-tests-kontrol.sh
+++ b/scripts/performance-tests-kontrol.sh
@@ -61,11 +61,11 @@ sed -i'' -e "s|'forge', 'build'|'forge', 'build', '--no-auto-detect'|g" src/kont
 sed -i'' -e "s|'forge', 'build'|'forge', 'build', '--no-auto-detect'|g" src/tests/integration/test_foundry_prove.py
 
 feature_shell() {
-  GC_DONT_GC=1 nix develop github:runtimeverification/evm-semantics/$KEVM_VERSION --extra-experimental-features 'nix-command flakes' --override-input k-framework/booster-backend $SCRIPT_DIR/../ --command bash -c "$1"
+  GC_DONT_GC=1 nix develop . --extra-experimental-features 'nix-command flakes' --override-input kevm/k-framework/booster-backend $SCRIPT_DIR/../ --command bash -c "$1"
 }
 
 master_shell() {
-  GC_DONT_GC=1 nix develop github:runtimeverification/evm-semantics/$KEVM_VERSION --extra-experimental-features 'nix-command flakes' --override-input k-framework/booster-backend github:runtimeverification/hs-backend-booster/$MASTER_COMMIT --command bash -c "$1"
+  GC_DONT_GC=1 nix develop . --extra-experimental-features 'nix-command flakes' --override-input kevm/k-framework/booster-backend github:runtimeverification/hs-backend-booster/$MASTER_COMMIT --command bash -c "$1"
 }
 
 feature_shell "poetry install && poetry run kevm-dist --verbose build evm-semantics.plugin evm-semantics.haskell kontrol.foundry --jobs 4"

--- a/scripts/performance-tests-kontrol.sh
+++ b/scripts/performance-tests-kontrol.sh
@@ -10,6 +10,7 @@ KONTROL_VERSION=${KONTROL_VERSION:-'v0.1.49'}
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
 MASTER_COMMIT="$(git rev-parse origin/main)"
+MASTER_COMMIT_SHORT="$(git rev-parse --short origin/main)"
 
 FEATURE_BRANCH_NAME=${FEATURE_BRANCH_NAME:-"$(git rev-parse --abbrev-ref HEAD)"}
 FEATURE_BRANCH_NAME="${FEATURE_BRANCH_NAME//\//-}"
@@ -65,12 +66,10 @@ feature_shell "poetry install && poetry run kevm-dist --verbose build plugin has
 feature_shell "make test-integration TEST_ARGS='--maxfail=0 --numprocesses=$PYTEST_PARALLEL --use-booster -vv' | tee $SCRIPT_DIR/kontrol-$KONTROL_VERSION-$FEATURE_BRANCH_NAME.log"
 killall kore-rpc-booster || echo "no zombie processes found"
 
-if [ ! -e "$SCRIPT_DIR/kontrol-$KONTROL_VERSION-master-$MASTER_COMMIT.log" ]; then
-  master_shell "make test-integration TEST_ARGS='--maxfail=0 --numprocesses=$PYTEST_PARALLEL --use-booster -vv' | tee $SCRIPT_DIR/kontrol-$KONTROL_VERSION-master-$MASTER_COMMIT.log"
+if [ ! -e "$SCRIPT_DIR/kontrol-$KONTROL_VERSION-master-$MASTER_COMMIT_SHORT.log" ]; then
+  master_shell "make test-integration TEST_ARGS='--maxfail=0 --numprocesses=$PYTEST_PARALLEL --use-booster -vv' | tee $SCRIPT_DIR/kontrol-$KONTROL_VERSION-master-$MASTER_COMMIT_SHORT.log"
   killall kore-rpc-booster || echo "no zombie processes found"
 fi
 
 cd $SCRIPT_DIR
-grep ' call  ' kontrol-$KONTROL_VERSION-$FEATURE_BRANCH_NAME.log > kontrol-$KONTROL_VERSION-master-$MASTER_COMMIT.$FEATURE_BRANCH_NAME
-grep ' call  ' kontrol-$KONTROL_VERSION-master-$MASTER_COMMIT.log > kontrol-$KONTROL_VERSION-master-$MASTER_COMMIT.master
-python3 compare.py kontrol-$KONTROL_VERSION-master-$MASTER_COMMIT.$FEATURE_BRANCH_NAME kontrol-$KONTROL_VERSION-master-$MASTER_COMMIT.master > kontrol-$KONTROL_VERSION-master-$MASTER_COMMIT-$FEATURE_BRANCH_NAME-compare
+python3 compare.py kontrol-$KONTROL_VERSION-$FEATURE_BRANCH_NAME.log kontrol-$KONTROL_VERSION-master-$MASTER_COMMIT_SHORT.log > kontrol-$KONTROL_VERSION-master-$MASTER_COMMIT_SHORT-$FEATURE_BRANCH_NAME-compare


### PR DESCRIPTION
This should allow us to store only the `.log` files and do the ` call    ` filtering inside the python script, which should help de-clutter the produced files as the number of log files grows quickly....