### PR TITLE
Handle conflicting `DomainValue`s in `bindVariable`

### DIFF
--- a/library/Booster/Pattern/Unify.hs
+++ b/library/Booster/Pattern/Unify.hs
@@ -577,6 +577,7 @@ bindVariable var term = do
             case Map.lookup var currentSubst of
                 Just oldTerm
                     | oldTerm == term -> pure () -- already bound
+                    | DomainValue{} <- oldTerm, DomainValue{} <- term -> enqueueRegularProblem oldTerm term
                     | otherwise ->
                         -- the term in the binding could be _equivalent_
                         -- (not necessarily syntactically equal) to term'


### PR DESCRIPTION
In #408, we've made conflicting variable assignment during unification indeterminate rather than failing. However, we can easily handle the case of conflicting domain values.

The motivation for this is the `foundry.prank` rule in Kontrol, which has a higher priority that the opcode fetching rule, and will be attempted at every EVM step, if `<prank>` is set to `true`. This will lead to Booster aborting every EVM step due to a conflicting assignment to the `CD` variable in the  `foundry.prank` rule.