### PR TITLE
Make ceil generation of in_keys more robust

### DIFF
--- a/library/Booster/Definition/Attributes/Base.hs
+++ b/library/Booster/Definition/Attributes/Base.hs
@@ -201,6 +201,7 @@ data SymbolAttributes = SymbolAttributes
     , hasEvaluators :: Flag "canBeEvaluated"
     , collectionMetadata :: Maybe KCollectionMetadata
     , smt :: Maybe SMTType
+    , hook :: Maybe Text
     }
     deriving stock (Eq, Ord, Show, Generic, Data, Lift)
     deriving anyclass (NFData, Hashable)

--- a/library/Booster/Definition/Attributes/Reader.hs
+++ b/library/Booster/Definition/Attributes/Reader.hs
@@ -188,6 +188,7 @@ instance HasAttributes ParsedSymbol where
             <*> hasConcreteEvaluators
             <*> pure Nothing
             <*> smt
+            <*> (attributes .:? "hook")
 
 instance HasAttributes ParsedSort where
     type Attributes ParsedSort = SortAttributes

--- a/library/Booster/Definition/Ceil.hs
+++ b/library/Booster/Definition/Ceil.hs
@@ -24,7 +24,7 @@ import Control.Monad.IO.Class (MonadIO (liftIO))
 import Control.Monad.Logger (MonadLoggerIO)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Writer (runWriterT, tell)
-import Data.ByteString.Char8 (isPrefixOf, stripPrefix)
+import Data.ByteString.Char8 (isPrefixOf)
 import Data.Coerce (coerce)
 import Data.Foldable (toList)
 import Data.Map qualified as Map
@@ -151,7 +151,7 @@ computeCeil (AndTerm l r) = concatMapM computeCeil [l, r]
 computeCeil (Injection _ _ t) = computeCeil t
 computeCeil (KMap _ keyVals rest) = do
     recArgs <- concatMapM computeCeil $ concat [[k, v] | (k, v) <- keyVals] <> maybeToList rest
-    symbols <- (.definition.symbols) <$> getConfig
+    symbols <- mkInKeysMap . (.definition.symbols) <$> getConfig
     pure $
         [Left $ Predicate $ mkNeq a b | a <- map fst keyVals, b <- map fst keyVals, a /= b]
             <> [ Left $ Predicate $ NotBool (mkInKeys symbols a rest') | a <- map fst keyVals, rest' <- maybeToList rest
@@ -178,33 +178,26 @@ mkNeq a b
     | sortOfTerm a == SortInt = NEqualsInt a b
     | otherwise = NEqualsK (KSeq (sortOfTerm a) a) (KSeq (sortOfTerm b) b)
 
-mkInKeys :: Map.Map SymbolName Symbol -> Term -> Term -> Term
-mkInKeys symbols k m
-    | sortOfTerm k == SortKItem && sortOfTerm m == SortMap =
-        SymbolApplication
-            ( Symbol
-                "Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'Unds'Bool'Unds'KItem'Unds'Map"
-                []
-                [SortKItem, SortMap]
-                SortBool
-                ( Booster.Definition.Attributes.Base.SymbolAttributes
-                    Booster.Definition.Attributes.Base.TotalFunction
-                    Booster.Definition.Attributes.Base.IsNotIdem
-                    Booster.Definition.Attributes.Base.IsNotAssoc
-                    Booster.Definition.Attributes.Base.IsNotMacroOrAlias
-                    Booster.Definition.Attributes.Base.CanBeEvaluated
-                    Nothing
-                    Nothing
-                )
-            )
-            []
-            [k, m]
-    | otherwise = case sortOfTerm m of
-        SortVar{} -> error "maformed map sort"
-        SortApp nm _ ->
-            case stripPrefix "Sort" nm of
-                Nothing -> error "maformed map sort"
-                Just mapName -> case Map.lookup ("Lbl" <> mapName <> "'Coln'in'Unds'keys") symbols of
-                    Just inKeysSymbol ->
-                        SymbolApplication inKeysSymbol [] [k, m]
-                    Nothing -> error "in_keys for this map sort does not exist"
+mkInKeysMap :: Map.Map SymbolName Symbol -> Map.Map (Sort, Sort) Symbol
+mkInKeysMap symbols =
+    Map.fromList
+        [ (sorts, sym)
+        | sym@Symbol{argSorts, attributes = SymbolAttributes{hook}} <- Map.elems symbols
+        , hook == Just "MAP.in_keys"
+        , sorts <- mTuple argSorts
+        ]
+  where
+    mTuple [x, y] = [(x, y)]
+    mTuple _ = []
+
+mkInKeys :: Map.Map (Sort, Sort) Symbol -> Term -> Term -> Term
+mkInKeys inKeysSymbols k m =
+    case Map.lookup (sortOfTerm k, sortOfTerm m) inKeysSymbols of
+        Just inKeysSymbol -> SymbolApplication inKeysSymbol [] [k, m]
+        Nothing ->
+            error $
+                "in_keys for key sort '"
+                    <> show (pretty $ sortOfTerm k)
+                    <> "' and map sort '"
+                    <> show (pretty $ sortOfTerm m)
+                    <> "' does not exist."

--- a/library/Booster/Pattern/Base.hs
+++ b/library/Booster/Pattern/Base.hs
@@ -190,6 +190,7 @@ unitSymbol def =
                 , hasEvaluators = CanBeEvaluated
                 , collectionMetadata = Just def
                 , smt = Nothing
+                , hook = Nothing
                 }
         }
   where
@@ -213,6 +214,7 @@ concatSymbol def =
                 , hasEvaluators = CanBeEvaluated
                 , collectionMetadata = Just def
                 , smt = Nothing
+                , hook = Nothing
                 }
         }
   where
@@ -238,6 +240,7 @@ kmapElementSymbol def =
                 , hasEvaluators = CanBeEvaluated
                 , collectionMetadata = Just $ KMapMeta def
                 , smt = Nothing
+                , hook = Nothing
                 }
         }
 
@@ -257,6 +260,7 @@ klistElementSymbol def =
                 , hasEvaluators = CanBeEvaluated
                 , collectionMetadata = Just $ KListMeta def
                 , smt = Nothing
+                , hook = Nothing
                 }
         }
 
@@ -693,6 +697,7 @@ injectionSymbol =
                 , hasEvaluators = CanBeEvaluated
                 , collectionMetadata = Nothing
                 , smt = Nothing
+                , hook = Nothing
                 }
         }
 
@@ -723,7 +728,16 @@ pattern KSeq sort a =
                 []
                 [SortKItem, SortK]
                 SortK
-                (SymbolAttributes Constructor IsNotIdem IsNotAssoc IsNotMacroOrAlias CanBeEvaluated Nothing Nothing)
+                ( SymbolAttributes
+                        Constructor
+                        IsNotIdem
+                        IsNotAssoc
+                        IsNotMacroOrAlias
+                        CanBeEvaluated
+                        Nothing
+                        Nothing
+                        Nothing
+                    )
             )
         []
         [ Injection sort SortKItem a
@@ -733,7 +747,16 @@ pattern KSeq sort a =
                         []
                         []
                         SortK
-                        (SymbolAttributes Constructor IsNotIdem IsNotAssoc IsNotMacroOrAlias CanBeEvaluated Nothing Nothing)
+                        ( SymbolAttributes
+                                Constructor
+                                IsNotIdem
+                                IsNotAssoc
+                                IsNotMacroOrAlias
+                                CanBeEvaluated
+                                Nothing
+                                Nothing
+                                Nothing
+                            )
                     )
                 []
                 []

--- a/library/Booster/Pattern/Binary.hs
+++ b/library/Booster/Pattern/Binary.hs
@@ -216,6 +216,7 @@ lookupKoreDefinitionSymbol name = DecodeM $ do
                         CannotBeEvaluated
                         Nothing
                         Nothing
+                        Nothing
                     )
         Just def -> Right $ Map.lookup name $ symbols def
 

--- a/library/Booster/Pattern/Bool.hs
+++ b/library/Booster/Pattern/Bool.hs
@@ -60,6 +60,7 @@ pattern TotalFunctionWithSMT hook =
         CanBeEvaluated
         Nothing
         (Just (SMTHook (Atom (SMTId hook))))
+        Nothing
 
 pattern AndBool :: Term -> Term -> Term
 pattern AndBool l r =
@@ -145,6 +146,7 @@ pattern SetIn a b =
                         IsNotAssoc
                         IsNotMacroOrAlias
                         CanBeEvaluated
+                        Nothing
                         Nothing
                         Nothing
                     )

--- a/library/Booster/Syntax/Json/Internalise.hs
+++ b/library/Booster/Syntax/Json/Internalise.hs
@@ -232,6 +232,7 @@ internaliseTermRaw qq allowAlias checkSubsorts sortVars definition@KoreDefinitio
                                     , hasEvaluators = Flag False
                                     , collectionMetadata = Nothing
                                     , smt = Nothing
+                                    , hook = Nothing
                                     }
                     else
                         maybe (throwE $ UnknownSymbol name symPatt) pure $

--- a/test/llvm-integration/LLVM.hs
+++ b/test/llvm-integration/LLVM.hs
@@ -473,6 +473,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -492,6 +493,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -511,6 +513,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -530,6 +533,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -550,6 +554,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -569,6 +574,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -588,6 +594,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -607,6 +614,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -626,6 +634,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -645,6 +654,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -664,6 +674,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -683,6 +694,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -702,6 +714,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -721,6 +734,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -740,6 +754,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -759,6 +774,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -778,6 +794,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -797,6 +814,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -816,6 +834,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -835,6 +854,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -854,6 +874,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -873,6 +894,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -892,6 +914,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -911,6 +934,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -930,6 +954,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -949,6 +974,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -968,6 +994,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -987,6 +1014,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1006,6 +1034,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1025,6 +1054,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1044,6 +1074,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1063,6 +1094,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1082,6 +1114,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1101,6 +1134,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1120,6 +1154,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1139,6 +1174,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1158,6 +1194,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1177,6 +1214,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1196,6 +1234,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1215,6 +1254,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1234,6 +1274,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1253,6 +1294,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1272,6 +1314,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1291,6 +1334,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1310,6 +1354,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1329,6 +1374,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1348,6 +1394,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1367,6 +1414,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1386,6 +1434,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1405,6 +1454,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1424,6 +1474,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1443,6 +1494,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1462,6 +1514,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1481,6 +1534,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1500,6 +1554,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1519,6 +1574,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1538,6 +1594,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1558,6 +1615,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1577,6 +1635,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1596,6 +1655,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1615,6 +1675,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1634,6 +1695,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1654,6 +1716,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1674,6 +1737,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1693,6 +1757,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1712,6 +1777,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1731,6 +1797,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1750,6 +1817,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1769,6 +1837,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1788,6 +1857,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1807,6 +1877,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1826,6 +1897,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1845,6 +1917,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1864,6 +1937,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1883,6 +1957,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1902,6 +1977,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1921,6 +1997,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1940,6 +2017,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1959,6 +2037,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1978,6 +2057,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -1997,6 +2077,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2016,6 +2097,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2035,6 +2117,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2055,6 +2138,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2074,6 +2158,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2093,6 +2178,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2112,6 +2198,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2131,6 +2218,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2152,6 +2240,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2171,6 +2260,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2190,6 +2280,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2209,6 +2300,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2228,6 +2320,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2247,6 +2340,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2266,6 +2360,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2285,6 +2380,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2304,6 +2400,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2323,6 +2420,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2342,6 +2440,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2361,6 +2460,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2380,6 +2480,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2399,6 +2500,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2418,6 +2520,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2437,6 +2540,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2456,6 +2560,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2475,6 +2580,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2494,6 +2600,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2513,6 +2620,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2532,6 +2640,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2551,6 +2660,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2570,6 +2680,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2589,6 +2700,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2608,6 +2720,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2627,6 +2740,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2646,6 +2760,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2665,6 +2780,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2684,6 +2800,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2703,6 +2820,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2722,6 +2840,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2741,6 +2860,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2760,6 +2880,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2779,6 +2900,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2798,6 +2920,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2817,6 +2940,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2836,6 +2960,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2855,6 +2980,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2874,6 +3000,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2894,6 +3021,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2914,6 +3042,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2933,6 +3062,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2952,6 +3082,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2971,6 +3102,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -2990,6 +3122,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -3009,6 +3142,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -3028,6 +3162,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -3047,6 +3182,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -3066,6 +3202,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -3085,6 +3222,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -3104,6 +3242,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -3123,6 +3262,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -3142,6 +3282,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -3161,6 +3302,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -3180,6 +3322,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -3199,6 +3342,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -3218,6 +3362,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -3237,6 +3382,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -3256,6 +3402,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -3275,6 +3422,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -3294,6 +3442,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -3313,6 +3462,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -3332,6 +3482,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -3351,6 +3502,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -3371,6 +3523,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -3390,6 +3543,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -3410,6 +3564,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -3429,6 +3584,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -3448,6 +3604,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -3467,6 +3624,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -3486,6 +3644,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -3505,6 +3664,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -3525,6 +3685,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -3544,6 +3705,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -3563,6 +3725,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -3582,6 +3745,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -3601,6 +3765,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -3620,6 +3785,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -3639,6 +3805,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -3658,6 +3825,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )
@@ -3677,6 +3845,7 @@ defSymbols =
                         , isMacroOrAlias = IsNotMacroOrAlias
                         , hasEvaluators = CanBeEvaluated
                         , smt = Nothing
+                        , hook = Nothing
                         }
                 }
             )

--- a/unit-tests/Test/Booster/Fixture.hs
+++ b/unit-tests/Test/Booster/Fixture.hs
@@ -112,6 +112,7 @@ eqK =
                 , isMacroOrAlias = IsNotMacroOrAlias
                 , hasEvaluators = CanBeEvaluated
                 , smt = Just (SMTHook (Atom "="))
+                , hook = Nothing
                 }
         }
 kseq = [symb| symbol kseq{}(SortKItem{}, SortK{}) : SortK{} [constructor{}()] |]

--- a/unit-tests/Test/Booster/Pattern/Binary.hs
+++ b/unit-tests/Test/Booster/Pattern/Binary.hs
@@ -46,6 +46,7 @@ genSymbolUnknownSort =
                 CannotBeEvaluated
                 Nothing
                 Nothing
+                Nothing
     )
         <$> Gen.utf8 (Range.linear 0 32) Gen.alphaNum
 

--- a/unit-tests/Test/Booster/Pattern/Util.hs
+++ b/unit-tests/Test/Booster/Pattern/Util.hs
@@ -48,7 +48,7 @@ app s = SymbolApplication s []
 
 asConstructor :: SymbolAttributes
 asConstructor =
-    SymbolAttributes Constructor IsNotIdem IsNotAssoc IsNotMacroOrAlias CanBeEvaluated Nothing Nothing
+    SymbolAttributes Constructor IsNotIdem IsNotAssoc IsNotMacroOrAlias CanBeEvaluated Nothing Nothing Nothing
 
 con1 :: Symbol
 con1 =


### PR DESCRIPTION
We were previously making the assumption that the only in_keys functions are those for the default built-in maps or cell maps. However, @virgil-serbanuta has a project which defines custom maps with a custom in_keys hook. In order to find the correct in_key symbol, we need to extract the "hook" attribute when internalising symbols and build a rverse lookup map for the given key and map sorts