### PR TITLE
More Abort/Fallback logging and better predicate simplification

### DIFF
--- a/library/Booster/CLOptions.hs
+++ b/library/Booster/CLOptions.hs
@@ -118,7 +118,8 @@ clOptionsParser =
 -- custom log levels that can be selected
 allowedLogLevels :: [(String, String)]
 allowedLogLevels =
-    [ ("Rewrite", "Log all rewriting in booster")
+    [ ("Aborts", "Log information related to aborting execution")
+    , ("Rewrite", "Log all rewriting in booster")
     , ("RewriteKore", "Log all rewriting in kore-rpc fall-backs")
     , ("RewriteSuccess", "Log successful rewrites (booster and kore-rpc)")
     , ("Simplify", "Log all simplification/evaluation in booster")

--- a/library/Booster/JsonRpc.hs
+++ b/library/Booster/JsonRpc.hs
@@ -245,6 +245,7 @@ respond stateVar =
                                 "booster"
                                 (Log.LevelOther "ErrorDetails")
                                 (Text.unlines $ map prettyPattern ps.unsupported)
+                        Log.logOtherNS "booster" (Log.LevelOther "Simplify") $ renderText (pretty ps)
                         ApplyEquations.simplifyConstraints
                             doTracing
                             def

--- a/library/Booster/Pattern/ApplyEquations.hs
+++ b/library/Booster/Pattern/ApplyEquations.hs
@@ -702,8 +702,8 @@ simplifyConstraints ::
     io (Either EquationFailure [Predicate], [EquationTrace], SimplifierCache)
 simplifyConstraints doTracing def mbApi mbSMT cache ps =
     runEquationT doTracing def mbApi mbSMT cache $
-        concatMap splitAndBools <$>
-            mapM ((coerce <$>) . simplifyConstraint' True . coerce) ps
+        concatMap splitAndBools
+            <$> mapM ((coerce <$>) . simplifyConstraint' True . coerce) ps
 
 -- version for internal nested evaluation
 simplifyConstraint' :: MonadLoggerIO io => Bool -> Term -> EquationT io Term

--- a/library/Booster/Pattern/ApplyEquations.hs
+++ b/library/Booster/Pattern/ApplyEquations.hs
@@ -60,7 +60,7 @@ import Booster.Pattern.Bool
 import Booster.Pattern.Index
 import Booster.Pattern.Match
 import Booster.Pattern.Util
-import Booster.Prettyprinter (renderDefault)
+import Booster.Prettyprinter (renderDefault, renderText)
 import Booster.SMT.Interface qualified as SMT
 
 newtype EquationT io a
@@ -237,8 +237,11 @@ iterateEquations ::
     EquationPreference ->
     Term ->
     EquationT io Term
-iterateEquations maxIterations direction preference startTerm =
-    go startTerm
+iterateEquations maxIterations direction preference startTerm = do
+    logOther (LevelOther "Simplify") $ "Evaluating " <> renderText (pretty startTerm)
+    result <- go startTerm
+    logOther (LevelOther "Simplify") $ "Result: " <> renderText (pretty result)
+    pure result
   where
     go :: MonadLoggerIO io => Term -> EquationT io Term
     go currentTerm

--- a/library/Booster/Pattern/Bool.hs
+++ b/library/Booster/Pattern/Bool.hs
@@ -193,8 +193,9 @@ splitBoolPredicates p@(Predicate t)
         AndBool l r -> concatMap (splitBoolPredicates . Predicate) [l, r]
         _other -> [p]
 
--- | Break apart a predicate composed of top-level Y1 andBool ... Yn
--- (not considering whether any of the subterms is concrete).
+{- | Break apart a predicate composed of top-level Y1 andBool ... Yn
+(not considering whether any of the subterms is concrete).
+-}
 splitAndBools :: Predicate -> [Predicate]
 splitAndBools p@(Predicate t)
     | AndBool l r <- t = concatMap (splitAndBools . Predicate) [l, r]

--- a/library/Booster/Pattern/Bool.hs
+++ b/library/Booster/Pattern/Bool.hs
@@ -9,6 +9,7 @@ module Booster.Pattern.Bool (
     isBottom,
     negateBool,
     splitBoolPredicates,
+    splitAndBools,
     -- patterns
     pattern TrueBool,
     pattern FalseBool,
@@ -190,4 +191,11 @@ splitBoolPredicates p@(Predicate t)
     | isConcrete t = [p]
     | otherwise = case t of
         AndBool l r -> concatMap (splitBoolPredicates . Predicate) [l, r]
-        other -> [Predicate other]
+        _other -> [p]
+
+-- | Break apart a predicate composed of top-level Y1 andBool ... Yn
+-- (not considering whether any of the subterms is concrete).
+splitAndBools :: Predicate -> [Predicate]
+splitAndBools p@(Predicate t)
+    | AndBool l r <- t = concatMap (splitAndBools . Predicate) [l, r]
+    | otherwise = [p]

--- a/library/Booster/Pattern/Rewrite.hs
+++ b/library/Booster/Pattern/Rewrite.hs
@@ -608,6 +608,7 @@ performRewrite doTracing def mLlvmLibrary mSolver mbMaxDepth cutLabels terminalL
     logRewrite = logOther (LevelOther "Rewrite")
     logRewriteSuccess = logOther (LevelOther "RewriteSuccess")
     logSimplify = logOther (LevelOther "Simplify")
+    logAborts = logOther (LevelOther "Aborts")
 
     prettyText :: Pretty a => a -> Text
     prettyText = pack . renderDefault . pretty
@@ -794,6 +795,7 @@ performRewrite doTracing def mLlvmLibrary mSolver mbMaxDepth cutLabels terminalL
                                 withSimplified pat' "Retrying with simplified pattern" (doSteps True)
                         Left failure -> do
                             rewriteTrace $ RewriteStepFailed failure
+                            logAborts . renderText $ pretty failure
                             let msg = "Aborted after " <> showCounter counter
                             if wasSimplified
                                 then logRewrite msg >> pure (RewriteAborted failure pat')

--- a/library/Booster/Syntax/Json/Internalise.hs
+++ b/library/Booster/Syntax/Json/Internalise.hs
@@ -109,9 +109,9 @@ instance Pretty InternalisedPredicates where
     pretty ps =
         Pretty.vsep $
             ("Bool predicates: " : map pretty (Set.toList ps.boolPredicates))
-            <> ("Ceil predicates: " : map pretty (Set.toList ps.ceilPredicates))
-            <> ("Substitution: " : map pretty (Map.assocs ps.substitution))
-            <> ("Unsupported predicates: " : map (pretty . show) ps.unsupported)
+                <> ("Ceil predicates: " : map pretty (Set.toList ps.ceilPredicates))
+                <> ("Substitution: " : map pretty (Map.assocs ps.substitution))
+                <> ("Unsupported predicates: " : map (pretty . show) ps.unsupported)
 
 data TermOrPredicates -- = Either Predicate Pattern
     = Predicates InternalisedPredicates

--- a/library/Booster/Syntax/Json/Internalise.hs
+++ b/library/Booster/Syntax/Json/Internalise.hs
@@ -57,7 +57,8 @@ import Data.Text as Text (Text, intercalate, pack, unpack)
 import Data.Text.Encoding (decodeLatin1)
 import Language.Haskell.TH (ExpQ, Lit (..), appE, litE, mkName, varE)
 import Language.Haskell.TH.Quote
-import Prettyprinter (pretty)
+import Prettyprinter (Pretty (..), pretty)
+import Prettyprinter qualified as Pretty
 
 import Booster.Definition.Attributes.Base
 import Booster.Definition.Attributes.Base qualified as Internal
@@ -103,6 +104,14 @@ data InternalisedPredicates = InternalisedPredicates
     , unsupported :: [Syntax.KorePattern]
     }
     deriving stock (Eq, Show)
+
+instance Pretty InternalisedPredicates where
+    pretty ps =
+        Pretty.vsep $
+            ("Bool predicates: " : map pretty (Set.toList ps.boolPredicates))
+            <> ("Ceil predicates: " : map pretty (Set.toList ps.ceilPredicates))
+            <> ("Substitution: " : map pretty (Map.assocs ps.substitution))
+            <> ("Unsupported predicates: " : map (pretty . show) ps.unsupported)
 
 data TermOrPredicates -- = Either Predicate Pattern
     = Predicates InternalisedPredicates

--- a/tools/booster/Proxy.hs
+++ b/tools/booster/Proxy.hs
@@ -138,12 +138,12 @@ respondEither ProxyConfig{statsVar, forceFallback, boosterState} booster kore re
                         logStats SimplifyM (boosterTime + koreTime, koreTime)
                         when (koreRes.state /= boosterRes.state) $ do
                             bState <- liftIO (MVar.readMVar boosterState)
-                            let m = fromMaybe bState.defaultMain simplifyReq._module
-                                def =
-                                    fromMaybe (error $ "Module " <> show m <> " not found") $
-                                        Map.lookup m bState.definitions
-                            Log.logOtherNS "proxy" (Log.LevelOther "Simplify") $
-                                let diff =
+                            Log.logOtherNS "proxy" (Log.LevelOther "Aborts") $
+                                let m = fromMaybe bState.defaultMain simplifyReq._module
+                                    def =
+                                        fromMaybe (error $ "Module " <> show m <> " not found") $
+                                            Map.lookup m bState.definitions
+                                    diff =
                                         fromMaybe "<syntactic difference only>" $
                                             diffBy def boosterRes.state.term koreRes.state.term
                                  in Text.pack ("Kore simplification: Diff (< before - > after)\n" <> diff)

--- a/tools/rpc-client/RpcClient.hs
+++ b/tools/rpc-client/RpcClient.hs
@@ -114,6 +114,9 @@ makeRequest time name s request handleResponse = do
     readResponse :: IO BS.ByteString
     readResponse = do
         part <- recv s bufSize
+        when (BS.length part == 0) $ do
+            putStrLn "[Error] Empty response from server. Did the server crash?"
+            exitWith (ExitFailure 3)
         if '\n' `BS.elem` part
             then pure part
             else do


### PR DESCRIPTION
Logging changes
* Log abort reasons and fall-back result during `execute` requests at level `Aborts`
* log simplification differences between booster and kore-rpc at `Aborts` level (instead of `Simplify`)
* print internalised predicates for predicate `simplify` requests
* print each predicate before/after simplification

Simplification changes
* Retain top-level `notBool` in predicates for evaluation with equations (some simplification rules require it to fire)
* Split up `andBool` into several predicates when returning from `simplifyConstraints`

The simplification changes get the booster simplification results closer to the kore-rpc simplification result (the fall-back simplification produces smaller differences).