### PR TITLE
Hotfix avoid entering a bogus equation loop through recursion

### DIFF
--- a/library/Booster/Pattern/ApplyEquations.hs
+++ b/library/Booster/Pattern/ApplyEquations.hs
@@ -721,7 +721,6 @@ simplifyConstraint' recurseIntoEvalBool = \case
                             then TrueBool
                             else FalseBool
                 Nothing -> if recurseIntoEvalBool then evalBool t else pure t
-    t@(NotBool _) -> evalBool t -- always evaluate under notBool
     EqualsK (KSeq _ l) (KSeq _ r) -> evalEqualsK l r
     NEqualsK (KSeq _ l) (KSeq _ r) -> negateBool <$> evalEqualsK l r
     t -> if recurseIntoEvalBool then evalBool t else pure t

--- a/library/Booster/Pattern/Rewrite.hs
+++ b/library/Booster/Pattern/Rewrite.hs
@@ -665,10 +665,12 @@ performRewrite doTracing def mLlvmLibrary mSolver mbMaxDepth cutLabels terminalL
                     rewriteTrace $ RewriteSimplified traces (Just r)
                     pure $ Just p
                 Left r@(EquationLoop (t : ts)) -> do
-                    let termDiffs = zipWith (curry mkDiffTerms) (t : ts) ts
                     logError "Equation evaluation loop"
-                    logSimplify $
-                        "produced the evaluation loop: " <> Text.unlines (map (prettyText . fst) termDiffs)
+                    logOtherNS "booster" (LevelOther "ErrorDetails") $
+                        let termDiffs = zipWith (curry mkDiffTerms) (t : ts) ts
+                            l = length ts
+                         in "Evaluation loop of length " <> prettyText l <> ": \n" <>
+                              Text.unlines (map (prettyText . fst) termDiffs)
                     rewriteTrace $ RewriteSimplified traces (Just r)
                     pure $ Just p
                 Left other -> do

--- a/library/Booster/Pattern/Rewrite.hs
+++ b/library/Booster/Pattern/Rewrite.hs
@@ -669,8 +669,10 @@ performRewrite doTracing def mLlvmLibrary mSolver mbMaxDepth cutLabels terminalL
                     logOtherNS "booster" (LevelOther "ErrorDetails") $
                         let termDiffs = zipWith (curry mkDiffTerms) (t : ts) ts
                             l = length ts
-                         in "Evaluation loop of length " <> prettyText l <> ": \n" <>
-                              Text.unlines (map (prettyText . fst) termDiffs)
+                         in "Evaluation loop of length "
+                                <> prettyText l
+                                <> ": \n"
+                                <> Text.unlines (map (prettyText . fst) termDiffs)
                     rewriteTrace $ RewriteSimplified traces (Just r)
                     pure $ Just p
                 Left other -> do


### PR DESCRIPTION
Yesterday's change in #430  to include a top-level `notBool` (so that simplifications can be applied to it) ends up recursively calling evaluation of the same term (i.e., a bogus evaluation loop of size 1) in some KEVM test proofs.
This fix adds back the recursion breaking flag to protect against this (the test behaves normally again with this fix). 