### PR TITLE
Refactor equals k to follow hook structure

### DIFF
--- a/library/Booster/Pattern/Bool.hs
+++ b/library/Booster/Pattern/Bool.hs
@@ -24,6 +24,7 @@ module Booster.Pattern.Bool (
 ) where
 
 import Data.ByteString.Char8 (ByteString)
+import Data.Text (Text)
 
 import Booster.Definition.Attributes.Base (
     SMTType (SMTHook),
@@ -62,6 +63,18 @@ pattern TotalFunctionWithSMT hook =
         Nothing
         (Just (SMTHook (Atom (SMTId hook))))
         Nothing
+
+pattern HookedFunctionWithSMT :: Text -> ByteString -> SymbolAttributes
+pattern HookedFunctionWithSMT hook smt =
+    SymbolAttributes
+        TotalFunction
+        IsNotIdem
+        IsNotAssoc
+        IsNotMacroOrAlias
+        CanBeEvaluated
+        Nothing
+        (Just (SMTHook (Atom (SMTId smt))))
+        (Just hook)
 
 pattern AndBool :: Term -> Term -> Term
 pattern AndBool l r =
@@ -130,7 +143,7 @@ pattern EqualsK a b =
                 []
                 [SortK, SortK]
                 SortBool
-                (TotalFunctionWithSMT "=")
+                (HookedFunctionWithSMT "KEQUAL.eq" "=")
             )
         []
         [a, b]
@@ -161,7 +174,7 @@ pattern NEqualsK a b =
                 []
                 [SortK, SortK]
                 SortBool
-                (TotalFunctionWithSMT "distinct")
+                (HookedFunctionWithSMT "KEQUAL.ne" "distinct")
             )
         []
         [a, b]

--- a/unit-tests/Test/Booster/Fixture.hs
+++ b/unit-tests/Test/Booster/Fixture.hs
@@ -112,7 +112,7 @@ eqK =
                 , isMacroOrAlias = IsNotMacroOrAlias
                 , hasEvaluators = CanBeEvaluated
                 , smt = Just (SMTHook (Atom "="))
-                , hook = Nothing
+                , hook = Just "KEQUAL.eq"
                 }
         }
 kseq = [symb| symbol kseq{}(SortKItem{}, SortK{}) : SortK{} [constructor{}()] |]

--- a/unit-tests/Test/Booster/Pattern/ApplyEquations.hs
+++ b/unit-tests/Test/Booster/Pattern/ApplyEquations.hs
@@ -172,8 +172,8 @@ test_simplifyConstraint =
                     "Same constructor, different variables"
                     [trm| con1{}(A:SomeSort{}) |]
                     [trm| con1{}(B:SomeSort{}) |]
-                    (const (EqualsK (KSeq someSort [trm| A:SomeSort{} |]) (KSeq someSort [trm| B:SomeSort{} |])))
-                    (const (EqualsK (KSeq someSort [trm| B:SomeSort{} |]) (KSeq someSort [trm| A:SomeSort{} |])))
+                    id
+                    id
                 , testCaseEqualsK
                     "Different constructors, same variable"
                     [trm| con1{}(A:SomeSort{}) |]


### PR DESCRIPTION
Behaviour has changed:
If the hook cannot evaluate the entire expression, the _original_ term will be returned. Previously, a simplified version would be returned. For instance, for a simplification of expression `Constr(A, 42) ==K Constr(B, 42)`, the old version returned `A ==K B`, whereas the new version returns the original term `Constr(A, 42) ==K Constr(B, 42)`.