### PR TITLE
Report rewrite as stuck when term index is none

### DIFF
--- a/test/rpc-integration/test-questionmark-vars/response-one-ques.booster-dev
+++ b/test/rpc-integration/test-questionmark-vars/response-one-ques.booster-dev
@@ -2,7 +2,7 @@
     "jsonrpc": "2.0",
     "id": 1,
     "result": {
-        "reason": "aborted",
+        "reason": "stuck",
         "depth": 1,
         "state": {
             "term": {

--- a/test/rpc-integration/test-questionmark-vars/response-two-ques-external.booster-dev
+++ b/test/rpc-integration/test-questionmark-vars/response-two-ques-external.booster-dev
@@ -2,7 +2,7 @@
     "jsonrpc": "2.0",
     "id": 1,
     "result": {
-        "reason": "aborted",
+        "reason": "stuck",
         "depth": 1,
         "state": {
             "term": {

--- a/test/rpc-integration/test-questionmark-vars/response-two-ques-internal-with-counter.booster-dev
+++ b/test/rpc-integration/test-questionmark-vars/response-two-ques-internal-with-counter.booster-dev
@@ -2,7 +2,7 @@
     "jsonrpc": "2.0",
     "id": 1,
     "result": {
-        "reason": "aborted",
+        "reason": "stuck",
         "depth": 2,
         "state": {
             "term": {

--- a/test/rpc-integration/test-questionmark-vars/response-two-ques-internal.booster-dev
+++ b/test/rpc-integration/test-questionmark-vars/response-two-ques-internal.booster-dev
@@ -2,7 +2,7 @@
     "jsonrpc": "2.0",
     "id": 1,
     "result": {
-        "reason": "aborted",
+        "reason": "stuck",
         "depth": 2,
         "state": {
             "term": {

--- a/unit-tests/Test/Booster/Pattern/Rewrite.hs
+++ b/unit-tests/Test/Booster/Pattern/Rewrite.hs
@@ -321,7 +321,8 @@ canRewrite =
                 [trm| kCell{}( kseq{}( inj{SomeSort{}, SortKItem{}}( con3{}( \dv{SomeSort{}}("thing"), \dv{SomeSort{}}("thing") ) ), C:SortK{}) ) |]
                 RewriteStuck
         , testCase "Returns stuck when term index is None" $
-            getsStuck [trm| kCell{}( kseq{}( inj{SomeSort{}, SortKItem{}}( \and{SomeSort{}}( con1{}( \dv{SomeSort{}}("thing") ), con2{}( \dv{SomeSort{}}("thing") ) ) ), C:SortK{} ) ) |]
+            getsStuck
+                [trm| kCell{}( kseq{}( inj{SomeSort{}, SortKItem{}}( \and{SomeSort{}}( con1{}( \dv{SomeSort{}}("thing") ), con2{}( \dv{SomeSort{}}("thing") ) ) ), C:SortK{} ) ) |]
         ]
 
 abortsOnErrors :: TestTree


### PR DESCRIPTION
Closes #457

When a term's index is `None`, the terms is stuck.

Previously, `rewriteStep` threw an exception when a term's index was `None`, causing an `RewriteAborted` result to be returned by `performRewrite`, leading to `Aborted` execute response. 

