### PR TITLE
Add build time to version info

### DIFF
--- a/library/Booster/CLOptions.hs
+++ b/library/Booster/CLOptions.hs
@@ -217,6 +217,7 @@ versionInfoStr =
         , "  revision:\t" <> gitHash <> if gitDirty then " (dirty)" else ""
         , "  branch:\t" <> fromMaybe "<unknown>" gitBranch
         , "  last commit:\t" <> gitCommitDate
+        , "  build time:\t" <> buildDate
         ]
   where
-    VersionInfo{gitHash, gitDirty, gitBranch, gitCommitDate} = $versionInfo
+    VersionInfo{gitHash, gitDirty, gitBranch, gitCommitDate, buildDate} = $versionInfo

--- a/library/Booster/VersionInfo.hs
+++ b/library/Booster/VersionInfo.hs
@@ -14,11 +14,14 @@ module Booster.VersionInfo (
 import Data.Aeson (
     FromJSON,
  )
+import Data.Time (getCurrentTime)
 import Development.GitRev qualified as GitRev
 import GHC.Generics qualified as GHC
 import Language.Haskell.TH (
     Exp,
     Q,
+    runIO,
+    stringE,
  )
 import Language.Haskell.TH.Syntax (
     Lift,
@@ -30,6 +33,7 @@ data VersionInfo = VersionInfo
     , gitCommitDate :: !String
     , gitBranch :: !(Maybe String)
     , gitDirty :: !Bool
+    , buildDate :: !String
     }
     deriving stock (GHC.Generic)
     deriving stock (Lift)
@@ -45,5 +49,6 @@ versionInfo =
             , gitCommitDate = $(GitRev.gitCommitDate)
             , gitBranch = Just $(GitRev.gitBranch)
             , gitDirty = $(GitRev.gitDirty)
+            , buildDate = $(stringE =<< runIO (show `fmap` Data.Time.getCurrentTime))
             }
         |]

--- a/package.yaml
+++ b/package.yaml
@@ -97,6 +97,7 @@ library:
   - syb
   - template-haskell
   - text
+  - time
   - transformers
   - unix
   - unliftio


### PR DESCRIPTION
This RP modifies the output of `kore-rpc-booster --version` to include the build time:

```
kore-rpc-booster --version
hs-backend-booster version:
  revision:	0f1143648471ab3ea61da49b7d8fff3fa67168a0 (dirty)
  branch:	georgy/better-unclear-condition
  last commit:	Wed Jan 24 10:10:46 2024 +0000
  build time:	2024-01-25 08:24:28.060971253 UTC
```
My primary motivation for this change is convincing myself that I'm not using a stale build when testing locally.