### PR TITLE
Use explicit IPv4 localhost address

### DIFF
--- a/tools/rpc-client/RpcClient.hs
+++ b/tools/rpc-client/RpcClient.hs
@@ -266,7 +266,7 @@ parseCommonOptions =
             ( long "host"
                 <> short 'h'
                 <> metavar "HOST"
-                <> value "localhost"
+                <> value "127.0.0.1"
                 <> help "server host to connect to"
                 <> showDefault
             )


### PR DESCRIPTION
I always had to pass `--host 127.0.0.1` on Arch Linux, because otherwise the client would try to connect to the IPv6 `localhost` by default. If it does not break anything, I'd be happy if we could merge that as it would significantly reduce friction on my system.

