### PR TITLE
Revert "Don't lose traces in Booster"

### DIFF
--- a/library/Booster/JsonRpc.hs
+++ b/library/Booster/JsonRpc.hs
@@ -619,19 +619,21 @@ execResponse mbDuration req (d, traces, rr) originalSubstitution unsupported = c
 
     logs =
         let traceLogs =
-                concat . catMaybes . toList $
-                    fmap
+                fmap concat
+                    . mapM
                         ( mkLogRewriteTrace
                             (logSuccessfulRewrites, logFailedRewrites)
                             (logSuccessfulSimplifications, logFailedSimplifications)
                         )
-                        traces
+                    $ toList traces
             timingLog =
                 fmap (ProcessingTime $ Just Booster) mbDuration
          in case (timingLog, traceLogs) of
-                (Nothing, []) -> Nothing
-                (Nothing, xs@(_ : _)) -> Just xs
-                (Just t, xs) -> Just (t : xs)
+                (Nothing, Nothing) -> Nothing
+                (Nothing, Just []) -> Nothing
+                (Nothing, Just xs@(_ : _)) -> Just xs
+                (Just t, Nothing) -> Just [t]
+                (Just t, Just xs) -> Just (t : xs)
 
 toExecState :: Pattern -> Map Variable Term -> [Syntax.KorePattern] -> RpcTypes.ExecuteState
 toExecState pat sub unsupported =


### PR DESCRIPTION
Reverts runtimeverification/hs-backend-booster#470 as this is causing a big regression in many KEVM tests:


| Test                                      | _update-deps-runtimeverification time | master time | (_update-deps-runtimeverification/master) time
|-------------------------------------------|-------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------
| mcd/vat-muluu-pass-spec.k                 | 167.63                                                                              | 159.21                                                                      | 1.0528861252433892
| benchmarks/overflow00-nooverflow-spec.k   | 150.79                                                                              | 141.13                                                                      | 1.0684475306455041
| mcd/flipper-addu48u48-fail-rough-spec.k   | 68.17                                                                               | 63.12                                                                       | 1.0800063371356148
| benchmarks/storagevar02-nooverflow-spec.k | 72.23                                                                               | 63.97                                                                       | 1.1291230264186338
| erc20/hkg/totalSupply-spec.k              | 54.82                                                                               | 48.19                                                                       | 1.1375804108736254
| mcd/end-subuu-pass-spec.k                 | 175.17                                                                              | 151.05                                                                      | 1.1596822244289968
| benchmarks/storagevar00-spec.k            | 61.62                                                                               | 52.94                                                                       | 1.1639591990933131
| benchmarks/storagevar03-spec.k            | 63.89                                                                               | 54.83                                                                       | 1.1652380083895677
| benchmarks/requires01-a0le0-spec.k        | 61.48                                                                               | 51.47                                                                       | 1.194482222653973
| benchmarks/address00-spec.k               | 60.21                                                                               | 50.4                                                                        | 1.1946428571428571
| benchmarks/overflow00-overflow-spec.k     | 60.22                                                                               | 49.86                                                                       | 1.2077817890092257
| examples/solidity-code-spec.md            | 242.8                                                                               | 199.55                                                                      | 1.2167376597344024
| erc20/hkg/allowance-spec.k                | 73.52                                                                               | 60.41                                                                       | 1.2170170501572588
| benchmarks/requires01-a0gt0-spec.k        | 63.79                                                                               | 52.09                                                                       | 1.2246112497600306
| benchmarks/storagevar01-spec.k            | 75.6                                                                                | 60.81                                                                       | 1.2432165762210161
| erc20/hkg/balanceOf-spec.k                | 67.95                                                                               | 51.28                                                                       | 1.3250780031201248
| benchmarks/encodepacked-keccak01-spec.k   | 68.18                                                                               | 51.14                                                                       | 1.3332029722330858
| benchmarks/dynamicarray00-spec.k          | 68.95                                                                               | 51.25                                                                       | 1.3453658536585367
| mcd/dsvalue-peek-pass-rough-spec.k        | 93.57                                                                               | 69.25                                                                       | 1.351191335740072
| benchmarks/staticarray00-spec.k           | 70.24                                                                               | 51.37                                                                       | 1.3673350204399455
| benchmarks/bytes00-spec.k                 | 81.9                                                                                | 59.36                                                                       | 1.3797169811320755
| benchmarks/keccak00-spec.k                | 79.38                                                                               | 57.48                                                                       | 1.3810020876826723
| mcd/dsvalue-read-pass-summarize-spec.k    | 90.77                                                                               | 65.58                                                                       | 1.3841110094541018
| mcd/dsvalue-read-pass-spec.k              | 99.08                                                                               | 69.29                                                                       | 1.4299321691441764
| mcd/cat-exhaustiveness-spec.k             | 200.98                                                                              | 137.62                                                                      | 1.4603981979363463
| benchmarks/staticloop00-a0lt10-spec.k     | 81.71                                                                               | 54.77                                                                       | 1.4918751141135655
| benchmarks/ecrecover00-siginvalid-spec.k  | 158.11                                                                              | 103.86                                                                      | 1.5223377623724246
| erc20/hkg/approve-spec.k                  | 82.9                                                                                | 54.4                                                                        | 1.5238970588235297
| benchmarks/ecrecover00-sigvalid-spec.k    | 174.33                                                                              | 105.61                                                                      | 1.6506959568222708
| erc20/hkg/transfer-failure-1-spec.k       | 127.21                                                                              | 77.01                                                                       | 1.6518633943643681
| erc20/ds/approve-failure-spec.k           | 95.03                                                                               | 57.22                                                                       | 1.6607829430269136
| erc20/hkg/transfer-failure-2-spec.k       | 114.24                                                                              | 67.93                                                                       | 1.6817311938760486
| erc20/hkg/transfer-success-2-spec.k       | 107.12                                                                              | 63.69                                                                       | 1.6818966870780343
| mcd/flipper-ttl-pass-spec.k               | 115.87                                                                              | 68.3                                                                        | 1.6964860907759884
| bihu/forwardToHotWallet-failure-3-spec.k  | 279.42                                                                              | 162.76                                                                      | 1.71676087490784
| mcd/vat-mului-pass-spec.k                 | 189.98                                                                              | 109.94                                                                      | 1.7280334728033473
| mcd/vat-addui-fail-rough-spec.k           | 167.7                                                                               | 96.33                                                                       | 1.7408906882591093
| mcd/flipper-tau-pass-spec.k               | 119.19                                                                              | 68.35                                                                       | 1.743818580833943
| erc20/hkg/transfer-success-1-spec.k       | 117.7                                                                               | 66.98                                                                       | 1.757240967452971
| mcd/vat-subui-fail-rough-spec.k           | 173.92                                                                              | 97.22                                                                       | 1.788932318452993
| benchmarks/encode-keccak00-spec.k         | 100.11                                                                              | 55.6                                                                        | 1.8005395683453236
| bihu/forwardToHotWallet-failure-1-spec.k  | 102.46                                                                              | 54.48                                                                       | 1.8806901615271658
| erc20/ds/transferFrom-failure-1-d-spec.k  | 133.82                                                                              | 70.06                                                                       | 1.9100770767913215
| erc20/ds/totalSupply-spec.k               | 104.03                                                                              | 54.24                                                                       | 1.917957227138643
| erc20/ds/transferFrom-failure-2-c-spec.k  | 120.99                                                                              | 61.93                                                                       | 1.953657355078314
| benchmarks/structarg00-spec.k             | 108.46                                                                              | 55.28                                                                       | 1.962011577424023
| mcd/vat-subui-pass-rough-spec.k           | 263.26                                                                              | 134.02                                                                      | 1.9643336815400685
| erc20/hkg/transferFrom-success-2-spec.k   | 153.93                                                                              | 75.44                                                                       | 2.0404294803817606
| mcd/vat-addui-pass-spec.k                 | 259.36                                                                              | 126.36                                                                      | 2.0525482747704973
| mcd/dstoken-approve-fail-rough-spec.k     | 217.6                                                                               | 104.04                                                                      | 2.091503267973856
| mcd/vat-subui-pass-spec.k                 | 270.33                                                                              | 127.63                                                                      | 2.1180756875342786
| erc20/hkg/transferFrom-success-1-spec.k   | 174.05                                                                              | 81.55                                                                       | 2.1342734518700186
| mcd/flopper-file-pass-rough-spec.k        | 843.75                                                                              | 394.77                                                                      | 2.137320465080933
| mcd/flopper-cage-pass-spec.k              | 160.45                                                                              | 72.05                                                                       | 2.2269257460097154
| mcd/cat-file-addr-pass-rough-spec.k       | 153.72                                                                              | 68.0                                                                        | 2.260588235294118
| mcd/flipper-bids-pass-rough-spec.k        | 309.23                                                                              | 136.46                                                                      | 2.26608529972153
| bihu/forwardToHotWallet-failure-4-spec.k  | 292.92                                                                              | 128.93                                                                      | 2.271930504925153
| erc20/hkg/transferFrom-failure-2-spec.k   | 205.36                                                                              | 89.59                                                                       | 2.2922201138519926
| bihu/forwardToHotWallet-success-2-spec.k  | 166.7                                                                               | 69.48                                                                       | 2.3992515831894066
| bihu/forwardToHotWallet-success-1-spec.k  | 162.69                                                                              | 66.97                                                                       | 2.429296700014932
| erc20/ds/balanceOf-spec.k                 | 136.71                                                                              | 55.68                                                                       | 2.455280172413793
| erc20/ds/transfer-failure-2-b-spec.k      | 142.72                                                                              | 57.58                                                                       | 2.4786384161167074
| erc20/ds/transfer-failure-1-c-spec.k      | 151.6                                                                               | 59.58                                                                       | 2.5444780127559583
| erc20/hkg/transferFrom-failure-1-spec.k   | 245.91                                                                              | 96.16                                                                       | 2.557300332778702
| mcd/dai-symbol-pass-spec.k                | 162.98                                                                              | 60.98                                                                       | 2.672679567071171
| erc20/ds/transferFrom-failure-1-a-spec.k  | 298.44                                                                              | 105.62                                                                      | 2.825601211891687
| bihu/forwardToHotWallet-failure-2-spec.k  | 222.92                                                                              | 78.35                                                                       | 2.845181876196554
| erc20/ds/transferFrom-failure-2-a-spec.k  | 267.35                                                                              | 86.82                                                                       | 3.0793595945634653
| erc20/ds/allowance-spec.k                 | 182.19                                                                              | 58.51                                                                       | 3.113826696291232
| mcd/vat-deny-diff-fail-rough-spec.k       | 410.02                                                                              | 121.91                                                                      | 3.3633007956689362
| erc20/ds/transferFrom-failure-1-b-spec.k  | 863.82                                                                              | 253.16                                                                      | 3.412150418707537
| erc20/ds/transfer-success-1-spec.k        | 458.84                                                                              | 131.81                                                                      | 3.4810712389044833
| erc20/ds/transferFrom-failure-2-b-spec.k  | 395.49                                                                              | 111.38                                                                      | 3.5508170228048126
| erc20/ds/transferFrom-failure-1-c-spec.k  | 437.06                                                                              | 121.39                                                                      | 3.600461323008485
| erc20/ds/transfer-failure-2-a-spec.k      | 292.2                                                                               | 80.95                                                                       | 3.6096355775169857
| erc20/ds/approve-success-spec.k           | 238.73                                                                              | 66.11                                                                       | 3.611102707608531
| erc20/ds/transfer-failure-1-a-spec.k      | 312.69                                                                              | 84.66                                                                       | 3.693479801559178
| mcd/vat-move-diff-rough-spec.k            | 654.25                                                                              | 163.2                                                                       | 4.0088848039215685
| examples/erc20-spec.md                    | 1165.6                                                                              | 273.3                                                                       | 4.264910354921331
| erc20/ds/transfer-failure-1-b-spec.k      | 528.95                                                                              | 113.8                                                                       | 4.6480667838312835
| erc20/ds/transfer-success-2-spec.k        | 378.52                                                                              | 77.4                                                                        | 4.890439276485788
| erc20/ds/transferFrom-success-1-spec.k    | 572.26                                                                              | 105.44                                                                      | 5.427352048558422
| erc20/ds/transferFrom-success-2-spec.k    | 520.26                                                                              | 95.71                                                                       | 5.435795632640268
| mcd/vat-slip-pass-rough-spec.k            | 1236.99                                                                             | 192.83                                                                      | 6.414925063527459
| examples/storage-spec.md                  | 1855.82                                                                             | 193.28                                                                      | 9.601717715231787
| TOTAL                                     | 20912.91                                                                            | 8049.509999999999                                                           | 2.5980351599041436
