### PR TITLE
Run single threaded by default

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -160,7 +160,6 @@ executables:
     ghc-options:
     - -rtsopts
     - -threaded
-    - -with-rtsopts=-N
 
 tests:
   unit-tests:


### PR DESCRIPTION
Remove pre-compiled RTS flag `-N` so that we default to `-N1`, i.e. run the RPC server single threaded by default.