### PR TITLE
Don't change directory in Nix flakes's dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -124,7 +124,7 @@
         (nixpkgsFor system).booster-backend.devShell.overrideAttrs (old: {
           shellHook = ''
             ${old.shellHook}
-            hpack && cd dev-tools && hpack
+            hpack && hpack dev-tools
           '';
         }));
     };


### PR DESCRIPTION
When the Nix flakes' dev shell is activated, the shell used to  end up in the `dev-tools` directory, rather than the project root directory. That broke things when the shell was hooked to `direnv` , as `.envrc` would suddenly be executed in wrong directory. This PR changes that.