### PR TITLE
Shorten simplification warning and error messages

### DIFF
--- a/library/Booster/JsonRpc.hs
+++ b/library/Booster/JsonRpc.hs
@@ -75,6 +75,7 @@ import Booster.Syntax.ParsedKore (parseKoreModule)
 import Booster.Syntax.ParsedKore.Base hiding (ParsedModule)
 import Booster.Syntax.ParsedKore.Base qualified as ParsedModule (ParsedModule (..))
 import Booster.Syntax.ParsedKore.Internalise (addToDefinitions)
+import Booster.Util (shortenText)
 import Data.Aeson (ToJSON (toJSON))
 import Data.Set qualified as Set
 import Kore.JsonRpc.Error qualified as RpcError
@@ -282,7 +283,7 @@ respond stateVar =
                         (Left (ApplyEquations.EquationLoop terms), _traces, _) ->
                             pure . Left . RpcError.backendError RpcError.Aborted $ map externaliseTerm terms -- FIXME
                         (Left other, _traces, _) ->
-                            pure . Left . RpcError.backendError RpcError.Aborted $ show other -- FIXME
+                            pure . Left . RpcError.backendError RpcError.Aborted $ (shortenText 32 . Text.pack . show $ other) -- FIXME
                             -- predicate only
                 Right (Predicates ps)
                     | null ps.boolPredicates && null ps.ceilPredicates && null ps.substitution && null ps.unsupported ->

--- a/library/Booster/JsonRpc.hs
+++ b/library/Booster/JsonRpc.hs
@@ -75,7 +75,7 @@ import Booster.Syntax.ParsedKore (parseKoreModule)
 import Booster.Syntax.ParsedKore.Base hiding (ParsedModule)
 import Booster.Syntax.ParsedKore.Base qualified as ParsedModule (ParsedModule (..))
 import Booster.Syntax.ParsedKore.Internalise (addToDefinitions)
-import Booster.Util (shortenText)
+import Booster.Util (constructorName)
 import Data.Aeson (ToJSON (toJSON))
 import Data.Set qualified as Set
 import Kore.JsonRpc.Error qualified as RpcError
@@ -283,7 +283,7 @@ respond stateVar =
                         (Left (ApplyEquations.EquationLoop terms), _traces, _) ->
                             pure . Left . RpcError.backendError RpcError.Aborted $ map externaliseTerm terms -- FIXME
                         (Left other, _traces, _) ->
-                            pure . Left . RpcError.backendError RpcError.Aborted $ (shortenText 32 . Text.pack . show $ other) -- FIXME
+                            pure . Left . RpcError.backendError RpcError.Aborted $ (Text.pack . constructorName $ other) -- FIXME
                             -- predicate only
                 Right (Predicates ps)
                     | null ps.boolPredicates && null ps.ceilPredicates && null ps.substitution && null ps.unsupported ->

--- a/library/Booster/LLVM/Internal.hs
+++ b/library/Booster/LLVM/Internal.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -Wno-unused-top-binds #-}
@@ -40,6 +41,7 @@ import Data.ByteString.Builder
 import Data.ByteString.Char8 (ByteString, pack)
 import Data.ByteString.Char8 qualified as BS
 import Data.ByteString.Lazy qualified as BL
+import Data.Data (Data)
 import Data.HashMap.Strict (HashMap)
 import Data.HashMap.Strict qualified as HM
 import Data.IORef (IORef, modifyIORef', newIORef, readIORef)
@@ -103,7 +105,7 @@ data KorePatternAPI = KorePatternAPI
 --     , isSuccess :: KoreErrorPtr -> IO Bool
 --     , message :: KoreErrorPtr -> IO ByteString
 --     }
-newtype LlvmError = LlvmError ByteString deriving (Show, Eq)
+newtype LlvmError = LlvmError ByteString deriving (Show, Eq, Data)
 
 data API = API
     { patt :: KorePatternAPI

--- a/library/Booster/Pattern/ApplyEquations.hs
+++ b/library/Booster/Pattern/ApplyEquations.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+
 {- |
 Copyright   : (c) Runtime Verification, 2022
 License     : BSD-3-Clause
@@ -41,6 +43,7 @@ import Control.Monad.Trans.Reader (ReaderT (..), ask)
 import Control.Monad.Trans.State
 import Data.ByteString.Char8 qualified as BS
 import Data.Coerce (coerce)
+import Data.Data (Data)
 import Data.Foldable (toList, traverse_)
 import Data.List (elemIndex, partition)
 import Data.Map (Map)
@@ -89,7 +92,7 @@ data EquationFailure
     | SideConditionFalse Predicate
     | InternalError Text
     | UndefinedTerm Term LLVM.LlvmError
-    deriving stock (Eq, Show)
+    deriving stock (Eq, Show, Data)
 
 instance Pretty EquationFailure where
     pretty = \case

--- a/library/Booster/Pattern/Rewrite.hs
+++ b/library/Booster/Pattern/Rewrite.hs
@@ -53,7 +53,7 @@ import Booster.Pattern.Unify
 import Booster.Pattern.Util
 import Booster.Prettyprinter
 import Booster.SMT.Interface qualified as SMT
-import Booster.Util (shortenText)
+import Booster.Util (constructorName)
 import Data.Coerce (coerce)
 
 newtype RewriteT io err a = RewriteT
@@ -713,7 +713,7 @@ performRewrite doTracing def mLlvmLibrary mSolver mbMaxDepth cutLabels terminalL
                     emitRewriteTrace $ RewriteSimplified traces (Just r)
                     pure $ Just p
                 Left other -> do
-                    logError $ "Simplification error during rewrite: " <> (shortenText 32 . Text.pack . show $ other)
+                    logError $ "Simplification error during rewrite: " <> (Text.pack . constructorName $ other)
                     emitRewriteTrace $ RewriteSimplified traces (Just other)
                     pure $ Just p
 

--- a/library/Booster/Pattern/Rewrite.hs
+++ b/library/Booster/Pattern/Rewrite.hs
@@ -53,6 +53,7 @@ import Booster.Pattern.Unify
 import Booster.Pattern.Util
 import Booster.Prettyprinter
 import Booster.SMT.Interface qualified as SMT
+import Booster.Util (shortenText)
 import Data.Coerce (coerce)
 
 newtype RewriteT io err a = RewriteT
@@ -712,7 +713,7 @@ performRewrite doTracing def mLlvmLibrary mSolver mbMaxDepth cutLabels terminalL
                     emitRewriteTrace $ RewriteSimplified traces (Just r)
                     pure $ Just p
                 Left other -> do
-                    logError . pack $ "Simplification error during rewrite: " <> show other
+                    logError $ "Simplification error during rewrite: " <> (shortenText 32 . Text.pack . show $ other)
                     emitRewriteTrace $ RewriteSimplified traces (Just other)
                     pure $ Just p
 

--- a/library/Booster/Util.hs
+++ b/library/Booster/Util.hs
@@ -1,12 +1,19 @@
 module Booster.Util (
     decodeLabel,
     decodeLabel',
+    shortenText,
 ) where
 
 import Data.ByteString (ByteString)
 import Data.ByteString.Char8 qualified as BS
 import Data.Either (fromRight)
 import Data.Map qualified as Map
+import Data.Text (Text)
+import Data.Text qualified as Text
+
+shortenText :: Int -> Text -> Text
+shortenText cutoff msg =
+    if Text.length msg < cutoff then msg else Text.take cutoff msg <> "...truncated"
 
 -- | Un-escapes special characters in symbol names
 decodeLabel :: ByteString -> Either String ByteString

--- a/library/Booster/Util.hs
+++ b/library/Booster/Util.hs
@@ -1,19 +1,17 @@
 module Booster.Util (
     decodeLabel,
     decodeLabel',
-    shortenText,
+    constructorName,
 ) where
 
 import Data.ByteString (ByteString)
 import Data.ByteString.Char8 qualified as BS
+import Data.Data
 import Data.Either (fromRight)
 import Data.Map qualified as Map
-import Data.Text (Text)
-import Data.Text qualified as Text
 
-shortenText :: Int -> Text -> Text
-shortenText cutoff msg =
-    if Text.length msg < cutoff then msg else Text.take cutoff msg <> "...truncated"
+constructorName :: Data a => a -> String
+constructorName x = showConstr (toConstr x)
 
 -- | Un-escapes special characters in symbol names
 decodeLabel :: ByteString -> Either String ByteString


### PR DESCRIPTION
When equation application fails with `TooManyIterations` or another data constructor of `EquationFailure`, we just `show` the data constructor, log it as a warning or return as error response (whichever is appropriate). However, it is usually only the data constructor tag (i.e. `TooManyIterations`) and not its arguments (usually huge terms) that is useful. This PR makes it so we print only the constructor name

**After:** 
```
[Warn#proxy] Problem with simplify request :  Aborted - TooManyRecursions [Term (TermAtt..............................................................................................................goes on forever.............................................
```


**After:** 
```
[Warn#proxy] Problem with simplify request :  Aborted - TooManyRecursions
```

