### PR TITLE
Protect LLVM library calls with a global lock

### DIFF
--- a/library/Booster/Definition/Ceil.hs
+++ b/library/Booster/Definition/Ceil.hs
@@ -13,8 +13,7 @@ import Booster.Definition.Attributes.Base
 import Booster.Pattern.ApplyEquations
 import Booster.Pattern.Base
 
-import Booster.LLVM (simplifyBool)
-import Booster.LLVM.Internal qualified as LLVM
+import Booster.LLVM as LLVM (API, simplifyBool)
 import Booster.Pattern.Bool
 import Booster.Pattern.Util (isConcrete, sortOfTerm)
 import Control.DeepSeq (NFData)

--- a/library/Booster/JsonRpc.hs
+++ b/library/Booster/JsonRpc.hs
@@ -43,7 +43,7 @@ import System.Clock (Clock (Monotonic), diffTimeSpec, getTime, toNanoSecs)
 import Booster.Definition.Attributes.Base (getUniqueId, uniqueId)
 import Booster.Definition.Base (KoreDefinition (..))
 import Booster.Definition.Base qualified as Definition (RewriteRule (..))
-import Booster.LLVM.Internal qualified as LLVM
+import Booster.LLVM as LLVM (API)
 import Booster.Pattern.ApplyEquations qualified as ApplyEquations
 import Booster.Pattern.Base (
     Pattern (..),

--- a/library/Booster/LLVM.hs
+++ b/library/Booster/LLVM.hs
@@ -1,4 +1,9 @@
-module Booster.LLVM (simplifyBool, simplifyTerm) where
+module Booster.LLVM (
+    simplifyBool,
+    simplifyTerm,
+    Internal.API,
+    Internal.LlvmError (..),
+) where
 
 import Control.Monad.IO.Class (MonadIO (..))
 import Data.Binary.Get

--- a/library/Booster/LLVM/Internal.hs
+++ b/library/Booster/LLVM/Internal.hs
@@ -24,7 +24,7 @@ module Booster.LLVM.Internal (
     LlvmError (..),
 ) where
 
-import Control.Concurrent.MVar (MVar, withMVar, newMVar)
+import Control.Concurrent.MVar (MVar, newMVar, withMVar)
 import Control.Monad (foldM, forM_, void, (>=>))
 import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow)
 import Control.Monad.IO.Class (MonadIO (..))

--- a/library/Booster/LLVM/Internal.hs
+++ b/library/Booster/LLVM/Internal.hs
@@ -24,13 +24,7 @@ module Booster.LLVM.Internal (
     LlvmError (..),
 ) where
 
-import Booster.LLVM.TH (dynamicBindings)
-import Booster.Pattern.Base
-import Booster.Pattern.Binary hiding (Block)
-import Booster.Pattern.Util (sortOfTerm)
-import Booster.Prettyprinter qualified as KPretty
-import Booster.Trace
-import Booster.Trace qualified as Trace
+import Control.Concurrent.MVar (MVar, withMVar, newMVar)
 import Control.Monad (foldM, forM_, void, (>=>))
 import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow)
 import Control.Monad.IO.Class (MonadIO (..))
@@ -55,6 +49,14 @@ import Foreign.Storable (peek)
 import GHC.Generics (Generic)
 import Prettyprinter (Pretty (..))
 import System.Posix.DynamicLinker qualified as Linker
+
+import Booster.LLVM.TH (dynamicBindings)
+import Booster.Pattern.Base
+import Booster.Pattern.Binary hiding (Block)
+import Booster.Pattern.Util (sortOfTerm)
+import Booster.Prettyprinter qualified as KPretty
+import Booster.Trace
+import Booster.Trace qualified as Trace
 
 data KorePattern
 data KoreSort
@@ -114,6 +116,7 @@ data API = API
     , simplifyBool :: KorePatternPtr -> IO (Either LlvmError Bool)
     , simplify :: KorePatternPtr -> KoreSortPtr -> IO (Either LlvmError ByteString)
     , collect :: IO ()
+    , mutex :: MVar ()
     }
 
 newtype LLVM a = LLVM (ReaderT API IO a)
@@ -181,7 +184,8 @@ withDLib :: FilePath -> (Linker.DL -> IO a) -> IO a
 withDLib dlib = Linker.withDL dlib [Linker.RTLD_LAZY]
 
 runLLVM :: API -> LLVM a -> IO a
-runLLVM api (LLVM m) = runReaderT m api
+runLLVM api (LLVM m) =
+    withMVar api.mutex $ const $ runReaderT m api
 
 mkAPI :: Linker.DL -> IO API
 mkAPI dlib = flip runReaderT dlib $ do
@@ -382,7 +386,8 @@ mkAPI dlib = flip runReaderT dlib $ do
                                             pure $ Right result
                                         else Left . LlvmError <$> errorMessage errPtr
 
-    pure API{patt, symbol, sort, simplifyBool, simplify, collect}
+    mutex <- liftIO $ newMVar ()
+    pure API{patt, symbol, sort, simplifyBool, simplify, collect, mutex}
   where
     traceCall call args retTy retPtr = do
         Trace.traceIO $ LlvmCall{ret = Just (retTy, somePtr retPtr), call, args}

--- a/library/Booster/Pattern/ApplyEquations.hs
+++ b/library/Booster/Pattern/ApplyEquations.hs
@@ -60,8 +60,7 @@ import Prettyprinter
 import Booster.Builtin as Builtin
 import Booster.Definition.Attributes.Base
 import Booster.Definition.Base
-import Booster.LLVM
-import Booster.LLVM.Internal qualified as LLVM
+import Booster.LLVM qualified as LLVM
 import Booster.Pattern.Base
 import Booster.Pattern.Bool
 import Booster.Pattern.Index
@@ -450,7 +449,7 @@ applyTerm direction pref trm = do
                         if isConcrete t && isJust config.llvmApi && attributes.canBeEvaluated
                             then -- LLVM simplification proceeds top-down and cuts the descent
 
-                                simplifyTerm (fromJust config.llvmApi) config.definition t (sortOfTerm t)
+                                LLVM.simplifyTerm (fromJust config.llvmApi) config.definition t (sortOfTerm t)
                                     >>= \case
                                         Left e -> throw $ UndefinedTerm t e
                                         Right result -> do
@@ -871,7 +870,7 @@ simplifyConstraint' recurseIntoEvalBool = \case
             mbApi <- (.llvmApi) <$> getConfig
             case mbApi of
                 Just api ->
-                    simplifyBool api t >>= \case
+                    LLVM.simplifyBool api t >>= \case
                         Left e ->
                             throw $ UndefinedTerm t e
                         Right res ->

--- a/library/Booster/Pattern/Rewrite.hs
+++ b/library/Booster/Pattern/Rewrite.hs
@@ -37,7 +37,7 @@ import Prettyprinter
 
 import Booster.Definition.Attributes.Base
 import Booster.Definition.Base
-import Booster.LLVM.Internal qualified as LLVM
+import Booster.LLVM as LLVM (API)
 import Booster.Pattern.ApplyEquations (
     EquationFailure (..),
     EquationTrace,

--- a/package.yaml
+++ b/package.yaml
@@ -205,8 +205,14 @@ tests:
       - hs-backend-booster
       - kore-rpc-types
       - process
+      - tasty
+      - tasty-hspec
       - text
       - transformers
+    ghc-options:
+    - -rtsopts
+    - -threaded
+    - -with-rtsopts=-N
 
   predicates-integration:
     source-dirs: test/predicates-integration

--- a/test/llvm-integration/LLVM.hs
+++ b/test/llvm-integration/LLVM.hs
@@ -34,6 +34,8 @@ import System.Info (os)
 import System.Process
 import Test.Hspec
 import Test.Hspec.Hedgehog
+import Test.Tasty
+import Test.Tasty.Hspec
 
 import Booster.Definition.Attributes.Base
 import Booster.Definition.Base
@@ -57,7 +59,7 @@ kompiledPath = "test/llvm-integration/definition/llvm-kompiled"
 dlPath = kompiledPath </> "interpreter" <.> (if os == "darwin" then ".dylib" else ".so")
 
 main :: IO ()
-main = hspec llvmSpec
+main = defaultMain =<< testSpec "LLVM simplification" llvmSpec
 
 llvmSpec :: Spec
 llvmSpec =
@@ -91,9 +93,9 @@ llvmSpec =
                 it "should work with latin-1strings" $
                     hedgehog . propertyTest . latin1Prop
 
-        beforeAll loadAPI $
-            it "should correct sort injections in non KItem maps" $
-                hedgehog . propertyTest . mapKItemInjProp
+            describe "special map tests" $
+                it "should correct sort injections in non KItem maps" $
+                    hedgehog . propertyTest . mapKItemInjProp
 
 --------------------------------------------------
 -- individual hedgehog property tests and helpers

--- a/test/llvm-integration/LLVM.hs
+++ b/test/llvm-integration/LLVM.hs
@@ -30,14 +30,15 @@ import Hedgehog.Gen qualified as Gen
 import Hedgehog.Internal.Property (Property (..))
 import Hedgehog.Range qualified as Range
 import System.FilePath
+import System.Info (os)
 import System.Process
 import Test.Hspec
 import Test.Hspec.Hedgehog
 
 import Booster.Definition.Attributes.Base
 import Booster.Definition.Base
-import Booster.LLVM as LLVM
-import Booster.LLVM.Internal as Internal
+import Booster.LLVM qualified as LLVM
+import Booster.LLVM.Internal qualified as Internal
 import Booster.Pattern.Base
 import Booster.Syntax.Json.Externalise (externaliseTerm)
 import Booster.Syntax.Json.Internalise (pattern AllowAlias, pattern IgnoreSubsorts)
@@ -45,7 +46,6 @@ import Booster.Syntax.Json.Internalise qualified as Syntax
 import Booster.Syntax.ParsedKore.Internalise (buildDefinitions, symb)
 import Booster.Syntax.ParsedKore.Parser (parseDefinition)
 import Kore.Syntax.Json.Types qualified as Syntax
-import System.Info (os)
 
 -- A prerequisite for all tests in this suite is that a fixed K
 -- definition was compiled in LLVM 'c' mode to produce a dynamic
@@ -64,12 +64,12 @@ llvmSpec =
     beforeAll_ runKompile $ do
         describe "Load an LLVM simplification library" $ do
             it "fails to load a non-existing library" $
-                withDLib "does/not/exist.dl" mkAPI
+                Internal.withDLib "does/not/exist.dl" Internal.mkAPI
                     `shouldThrow` \IOError{ioe_description = msg} ->
                         "does/not/exist" `isInfixOf` msg
             it ("loads a valid library from " <> dlPath) $ do
-                withDLib dlPath $ \dl -> do
-                    api <- mkAPI dl
+                Internal.withDLib dlPath $ \dl -> do
+                    api <- Internal.mkAPI dl
                     let testString = "testing, one, two, three"
                     s <- api.patt.string.new testString
                     api.patt.dump s `shouldReturn` show testString
@@ -101,7 +101,7 @@ llvmSpec =
 boolsRemainProp
     , compareNumbersProp
     , simplifyComparisonProp ::
-        Internal.API -> Property
+        LLVM.API -> Property
 boolsRemainProp api = property $ do
     b <- forAll Gen.bool
     res <- LLVM.simplifyBool api (boolTerm b)
@@ -120,7 +120,7 @@ simplifyComparisonProp api = property $ do
 anInt64 :: PropertyT IO Int64
 anInt64 = forAll $ Gen.integral (Range.constantBounded :: Range Int64)
 
-byteArrayProp :: Internal.API -> Property
+byteArrayProp :: LLVM.API -> Property
 byteArrayProp api = property $ do
     i <- forAll $ Gen.int (Range.linear 0 1024)
     let ba = BS.pack $ take i $ cycle ['\255', '\254' .. '\0']
@@ -133,7 +133,7 @@ byteArrayProp api = property $ do
 -- Round-trip test passing syntactic strings through the simplifier
 -- and back. latin-1 characters should be left as they are (treated as
 -- bytes internally). UTF-8 code points beyond latin-1 are forbidden.
-latin1Prop :: Internal.API -> Property
+latin1Prop :: LLVM.API -> Property
 latin1Prop api = property $ do
     txt <- forAll $ Gen.text (Range.linear 0 123) Gen.latin1
     let stringDV = fromSyntacticString txt
@@ -157,7 +157,7 @@ latin1Prop api = property $ do
                 | otherwise -> error $ "Unexpected sort " <> show s
             otherTerm -> error $ "Unexpected term " <> show otherTerm
 
-mapKItemInjProp :: Internal.API -> Property
+mapKItemInjProp :: LLVM.API -> Property
 mapKItemInjProp api = property $ do
     let k = wrapIntTerm 1
     let v = wrapIntTerm 2
@@ -209,8 +209,8 @@ runKompile = do
         , kompiledPath
         ]
 
-loadAPI :: IO API
-loadAPI = withDLib dlPath mkAPI
+loadAPI :: IO LLVM.API
+loadAPI = Internal.withDLib dlPath Internal.mkAPI
 
 ------------------------------------------------------------
 -- term construction


### PR DESCRIPTION
- also refactored some exports to avoid importing `LLVM.Internal`

Workaround until #488 can be worked on