### PR TITLE
Warn when loading an LLVM library compiled with --llvm-mutable-bytes

### DIFF
--- a/cbits/kllvm-c.h
+++ b/cbits/kllvm-c.h
@@ -112,7 +112,7 @@ char *kore_block_dump(block *);
 
 kore_pattern *kore_pattern_from_block(block *);
 
-/* 
+/*
  * Expects the argument term to be of the form:
  *   sym{}(BOOL)
  */
@@ -154,6 +154,10 @@ void kore_symbol_add_formal_argument(kore_symbol *, kore_sort const *);
 
 void kllvm_init(void);
 void kllvm_free_all_memory(void);
+
+/* Sort-specific functions */
+
+bool kllvm_mutable_bytes_enabled(void);
 
 #ifdef __cplusplus
 }

--- a/library/Booster/LLVM/Internal.hs
+++ b/library/Booster/LLVM/Internal.hs
@@ -27,8 +27,8 @@ module Booster.LLVM.Internal (
 import Control.Concurrent.MVar (MVar, newMVar, withMVar)
 import Control.Exception (IOException)
 import Control.Monad (foldM, forM_, void, (>=>))
-import Control.Monad.Extra (whenM)
 import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow, catch)
+import Control.Monad.Extra (whenM)
 import Control.Monad.IO.Class (MonadIO (..))
 import Control.Monad.Trans.Reader (ReaderT (runReaderT))
 import Control.Monad.Trans.Reader qualified as Reader
@@ -390,10 +390,12 @@ mkAPI dlib = flip runReaderT dlib $ do
                                         else Left . LlvmError <$> errorMessage errPtr
 
     mutableBytesEnabled <-
-        kllvmMutableBytesEnabled `catch` \ (_:: IOException) -> pure (pure 0)
+        kllvmMutableBytesEnabled `catch` \(_ :: IOException) -> pure (pure 0)
     liftIO $
         whenM ((/= 0) <$> mutableBytesEnabled) $
-            hPutStrLn stderr "[Warn] Using an LLVM backend compiled with --llvm-mutable-bytes (unsound byte array semantics)"
+            hPutStrLn
+                stderr
+                "[Warn] Using an LLVM backend compiled with --llvm-mutable-bytes (unsound byte array semantics)"
 
     mutex <- liftIO $ newMVar ()
     pure API{patt, symbol, sort, simplifyBool, simplify, collect, mutex}


### PR DESCRIPTION
(Although highly unlikely to cause issues,) The user should be warned if the llvm backend library loaded by the server was compiled using flag `--llvm-mutable-bytes`.

This is checked by calling `bool kllvm_mutable_bytes_enabled()` from the LLVM library's API.

Note that this flag function is only available in K version >= 6.2. Libraries built by older versions of K won't include the required function (the server will still work when attempting to load such an older library).

The behaviour has been manually tested locally (on Linux) using some of the integration tests.

Fixes #490 
