### PR TITLE
Stronger map matching

### DIFF
--- a/library/Booster/Pattern/Match.hs
+++ b/library/Booster/Pattern/Match.hs
@@ -13,9 +13,11 @@ import Control.Monad
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.Except
 import Control.Monad.Trans.State
+import Data.Bifunctor (first)
 import Data.Either.Extra
 import Data.Map (Map)
 import Data.Map qualified as Map
+import Data.Maybe (fromMaybe)
 import Data.Sequence (Seq (..), (><))
 import Data.Sequence qualified as Seq
 import Data.Set (Set)
@@ -268,25 +270,92 @@ match1
                 failWith $ DifferentSymbols app subj
 ----- KMap
 match1
-    t1@(KMap def1 keyVals1 Nothing)
-    t2@(KMap def2 keyVals2 Nothing)
-        | def1 == def2 =
-            if isConcrete t1 && isConcrete t2
-                then
-                    if keyVals1 == keyVals2 -- identical concrete maps match
-                        then pure mempty
-                        else failWith $ DifferentValues t1 t2
-                else indeterminate t1 t2 -- symbolic maps are indeterminate
-        | otherwise = failWith $ DifferentSorts t1 t2
--- matching on non-empty symbolic maps is not supported
+    t1@(KMap patDef patKeyVals patRest)
+    t2@(KMap subjDef subjKeyVals subjRest)
+        -- different map sorts do not match
+        | patDef /= subjDef = failWith $ DifferentSorts t1 t2
+        | otherwise = do
+            -- first apply current substitution to pattern key-value pairs
+            currentSubst <- gets mSubstitution
+            let patternKeyVals = map (first (substituteInTerm currentSubst)) patKeyVals
+
+            -- FIXME add two DuplicateKey checks here
+
+            let patMap = Map.fromList patternKeyVals
+                subjMap = Map.fromList subjKeyVals
+                -- handles syntactically identical keys in pattern and subject
+                commonMap = Map.intersectionWith (,) patMap subjMap
+                patExtra = patMap `Map.withoutKeys` Map.keysSet commonMap
+                subjExtra = subjMap `Map.withoutKeys` Map.keysSet commonMap
+
+            -- Before enqueueing the common elements for matching,
+            -- check whether we can abort early
+            case (Map.null patExtra, Map.null subjExtra) of
+                (True, True) ->
+                    -- all keys are common, handle opaque rest (if any)
+                    case patRest of
+                        Nothing ->
+                            maybe (pure ()) (enqueueProblem emptyMap) subjRest
+                        Just pRest ->
+                            enqueueProblem pRest $ fromMaybe emptyMap subjRest
+                (True, False) ->
+                    -- subject has extra assocs to match with pattern rest
+                    let subj' = KMap subjDef (Map.assocs subjExtra) subjRest
+                     in case patRest of
+                            Nothing ->
+                                failWith $ DifferentValues emptyMap subj'
+                            Just pRest -> do
+                                enqueueProblem pRest subj'
+                (False, True) ->
+                    -- pattern has extra assocs
+                    let pat' = KMap patDef (Map.assocs patExtra) patRest
+                     in case subjRest of
+                            Nothing ->
+                                -- no opaque rest, match is definitely failing
+                                failWith $ DifferentValues pat' emptyMap
+                            Just sRest ->
+                                -- indeterminate matching with an opaque rest
+                                indeterminate pat' sRest
+                (False, False)
+                    -- Special case: definitely fail if all (extra) pattern keys are concrete
+                    -- and there is no opaque subject rest
+                    | Nothing <- subjRest
+                    , all isConcrete (Map.keys patExtra) ->
+                        let pat' = KMap patDef (Map.assocs patExtra) patRest
+                            subj' = KMap subjDef (Map.assocs subjExtra) subjRest
+                         in failWith $ DifferentValues pat' subj'
+                    -- Special case: attempt a match if pattern and subject assocs
+                    -- are singleton and there is no opaque subject rest
+                    | Nothing <- subjRest
+                    , Map.size patExtra == 1
+                    , Map.size subjExtra == 1 -> do
+                        let (pKey, pVal) : _ = Map.assocs patExtra
+                            (sKey, sVal) : _ = Map.assocs subjExtra
+                            opaque = case patRest of
+                                Nothing -> []
+                                Just rest -> [(rest, emptyMap)]
+                        enqueueProblems . Seq.fromList $ (pKey, sKey) : (pVal, sVal) : opaque
+                    | otherwise ->
+                        indeterminate t1 t2
+
+            -- enqueue common elements for matching unless already failed
+            enqueueProblems $ Seq.fromList $ Map.elems commonMap
+      where
+        emptyMap = KMap patDef [] Nothing
+
+        -- checkDuplicateKeys :: Ord a => Set a -> _
+        checkDuplicateKeys keySet
+            | otherwise = pure ()
+
+--- not matching map patterns with anything else
 match1
     t1@KMap{}
     t2 = indeterminate t1 t2
--- no unification for lists, return indeterminate for now
+-- no matching for lists, return indeterminate for now
 match1
     t1@KList{}
     t2 = indeterminate t1 t2
--- no unification for sets, return indeterminate for now
+-- no matching for sets, return indeterminate for now
 match1
     t1@KSet{}
     t2 = indeterminate t1 t2

--- a/library/Booster/Pattern/Match.hs
+++ b/library/Booster/Pattern/Match.hs
@@ -90,24 +90,32 @@ matchTerm KoreDefinition{sorts} term1 term2 =
                     State
                         { mSubstitution = Map.empty
                         , mQueue = Seq.singleton (term1, term2)
+                        , mMapQueue = mempty
                         , mSubsorts = Map.map snd sorts
                         }
 
 data MatchState = State
     { mSubstitution :: Map Variable Term
     , mQueue :: Seq (Term, Term) -- work queue
+    , mMapQueue :: Seq (Term, Term) -- work queue for Map/Set matching (2nd priority)
     , mSubsorts :: Map SortName (Set SortName)
     }
 
 matching :: StateT MatchState (Except MatchResult) ()
 matching = do
-    queue <- gets mQueue
-    case queue of
-        Empty -> pure () -- done
+    st <- get
+    case st.mQueue of
         (term1, term2) :<| rest -> do
             modify $ \s -> s{mQueue = rest}
             match1 term1 term2
             matching
+        Empty ->
+            case st.mMapQueue of
+                (term1, term2) :<| rest -> do
+                    modify $ \s -> s{mMapQueue = rest}
+                    match1 term1 term2
+                    matching
+                Empty -> pure () -- done
 
 match1 ::
     Term ->
@@ -271,75 +279,81 @@ match1
 ----- KMap
 match1
     t1@(KMap patDef patKeyVals patRest)
-    t2@(KMap subjDef subjKeyVals subjRest)
+    t2@(KMap subjDef subjKeyVals subjRest) = do
         -- different map sorts do not match
-        | patDef /= subjDef = failWith $ DifferentSorts t1 t2
-        | otherwise = do
-            -- first apply current substitution to pattern key-value pairs
-            currentSubst <- gets mSubstitution
-            let patternKeyVals = map (first (substituteInTerm currentSubst)) patKeyVals
+        unless (patDef == subjDef) $
+            failWith (DifferentSorts t1 t2)
+        st <- get
+        if not (Seq.null st.mQueue)
+            then -- delay matching 'KMap's until there are no regular
+            -- problems left, to obtain a maximal prior substitution
+            -- before matching map keys.
+                enqueueMapProblem t1 t2
+            else do
+                -- first apply current substitution to pattern key-value pairs
+                let patternKeyVals = map (first (substituteInTerm st.mSubstitution)) patKeyVals
 
-            -- check for duplicate keys
-            checkDuplicateKeys (KMap patDef patternKeyVals patRest)
-            checkDuplicateKeys t2
+                -- check for duplicate keys
+                checkDuplicateKeys (KMap patDef patternKeyVals patRest)
+                checkDuplicateKeys t2
 
-            let patMap = Map.fromList patternKeyVals
-                subjMap = Map.fromList subjKeyVals
-                -- handles syntactically identical keys in pattern and subject
-                commonMap = Map.intersectionWith (,) patMap subjMap
-                patExtra = patMap `Map.withoutKeys` Map.keysSet commonMap
-                subjExtra = subjMap `Map.withoutKeys` Map.keysSet commonMap
+                let patMap = Map.fromList patternKeyVals
+                    subjMap = Map.fromList subjKeyVals
+                    -- handles syntactically identical keys in pattern and subject
+                    commonMap = Map.intersectionWith (,) patMap subjMap
+                    patExtra = patMap `Map.withoutKeys` Map.keysSet commonMap
+                    subjExtra = subjMap `Map.withoutKeys` Map.keysSet commonMap
 
-            -- Before enqueueing the common elements for matching,
-            -- check whether we can abort early
-            case (Map.null patExtra, Map.null subjExtra) of
-                (True, True) ->
-                    -- all keys are common, handle opaque rest (if any)
-                    case patRest of
-                        Nothing ->
-                            maybe (pure ()) (enqueueProblem emptyMap) subjRest
-                        Just pRest ->
-                            enqueueProblem pRest $ fromMaybe emptyMap subjRest
-                (True, False) ->
-                    -- subject has extra assocs to match with pattern rest
-                    let subj' = KMap subjDef (Map.assocs subjExtra) subjRest
-                     in case patRest of
+                -- Before enqueueing the common elements for matching,
+                -- check whether we can abort early
+                case (Map.null patExtra, Map.null subjExtra) of
+                    (True, True) ->
+                        -- all keys are common, handle opaque rest (if any)
+                        case patRest of
                             Nothing ->
-                                failWith $ DifferentValues emptyMap subj'
-                            Just pRest -> do
-                                enqueueProblem pRest subj'
-                (False, True) ->
-                    -- pattern has extra assocs
-                    let pat' = KMap patDef (Map.assocs patExtra) patRest
-                     in case subjRest of
-                            Nothing ->
-                                -- no opaque rest, match is definitely failing
-                                failWith $ DifferentValues pat' emptyMap
-                            Just sRest ->
-                                -- indeterminate matching with an opaque rest
-                                indeterminate pat' sRest
-                (False, False)
-                    -- Special case: definitely fail if all (extra) pattern keys are concrete
-                    -- and there is no opaque subject rest
-                    | Nothing <- subjRest
-                    , all isConcrete (Map.keys patExtra) ->
+                                maybe (pure ()) (enqueueProblem emptyMap) subjRest
+                            Just pRest ->
+                                enqueueProblem pRest $ fromMaybe emptyMap subjRest
+                    (True, False) ->
+                        -- subject has extra assocs to match with pattern rest
+                        let subj' = KMap subjDef (Map.assocs subjExtra) subjRest
+                         in case patRest of
+                                Nothing ->
+                                    failWith $ DifferentValues emptyMap subj'
+                                Just pRest -> do
+                                    enqueueProblem pRest subj'
+                    (False, True) ->
+                        -- pattern has extra assocs
                         let pat' = KMap patDef (Map.assocs patExtra) patRest
-                            subj' = KMap subjDef (Map.assocs subjExtra) subjRest
-                         in failWith $ DifferentValues pat' subj'
-                    -- Special case: attempt a match if pattern and subject assocs
-                    -- are singleton and there is no opaque subject rest
-                    | Nothing <- subjRest
-                    , [(pKey, pVal)] <- Map.assocs patExtra
-                    , [(sKey, sVal)] <- Map.assocs subjExtra -> do
-                        let opaque = case patRest of
-                                Nothing -> []
-                                Just rest -> [(rest, emptyMap)]
-                        enqueueProblems . Seq.fromList $ (pKey, sKey) : (pVal, sVal) : opaque
-                    | otherwise ->
-                        indeterminate t1 t2
+                         in case subjRest of
+                                Nothing ->
+                                    -- no opaque rest, match is definitely failing
+                                    failWith $ DifferentValues pat' emptyMap
+                                Just sRest ->
+                                    -- indeterminate matching with an opaque rest
+                                    indeterminate pat' sRest
+                    (False, False)
+                        -- Special case: definitely fail if all (extra) pattern keys are concrete
+                        -- and there is no opaque subject rest
+                        | Nothing <- subjRest
+                        , all isConcrete (Map.keys patExtra) ->
+                            let pat' = KMap patDef (Map.assocs patExtra) patRest
+                                subj' = KMap subjDef (Map.assocs subjExtra) subjRest
+                             in failWith $ DifferentValues pat' subj'
+                        -- Special case: attempt a match if pattern and subject assocs
+                        -- are singleton and there is no opaque subject rest
+                        | Nothing <- subjRest
+                        , [(pKey, pVal)] <- Map.assocs patExtra
+                        , [(sKey, sVal)] <- Map.assocs subjExtra -> do
+                            let opaque = case patRest of
+                                    Nothing -> []
+                                    Just rest -> [(rest, emptyMap)]
+                            enqueueProblems . Seq.fromList $ (pKey, sKey) : (pVal, sVal) : opaque
+                        | otherwise ->
+                            indeterminate t1 t2
 
-            -- enqueue common elements for matching unless already failed
-            enqueueProblems $ Seq.fromList $ Map.elems commonMap
+                -- enqueue common elements for matching unless already failed
+                enqueueProblems $ Seq.fromList $ Map.elems commonMap
       where
         emptyMap = KMap patDef [] Nothing
 
@@ -373,6 +387,10 @@ indeterminate t1 t2 = lift . throwE $ MatchIndeterminate t1 t2
 enqueueProblem :: Monad m => Term -> Term -> StateT MatchState m ()
 enqueueProblem term1 term2 =
     modify $ \s@State{mQueue} -> s{mQueue = mQueue :|> (term1, term2)}
+
+enqueueMapProblem :: Monad m => Term -> Term -> StateT MatchState m ()
+enqueueMapProblem term1 term2 =
+    modify $ \s@State{mMapQueue} -> s{mMapQueue = mMapQueue :|> (term1, term2)}
 
 enqueueProblems :: Monad m => Seq (Term, Term) -> StateT MatchState m ()
 enqueueProblems ts =

--- a/unit-tests/Test/Booster/Pattern/Match.hs
+++ b/unit-tests/Test/Booster/Pattern/Match.hs
@@ -199,25 +199,113 @@ kmapTerms =
             concreteKMapWithOneItem
             (success [])
         , test
-            "Empty KMap on the left, non-empty concrete KMap on the right: failed"
+            "Empty KMap ~= non-empty concrete KMap: fails"
             emptyKMap
             concreteKMapWithOneItem
-            (MatchFailed (General (DifferentValues emptyKMap concreteKMapWithOneItem)))
+            (failed $ DifferentValues emptyKMap concreteKMapWithOneItem)
         , test
-            "Non-empty concrete KMap on the left, empty KMap on the right: failed"
+            "Non-empty concrete KMap ~= empty KMap: fails"
             concreteKMapWithOneItem
             emptyKMap
-            (MatchFailed (General (DifferentValues concreteKMapWithOneItem emptyKMap)))
+            (failed $ DifferentValues concreteKMapWithOneItem emptyKMap)
         , test
-            "Non-empty symbolic KMap on the left, empty KMap on the right: indeterminate"
+            "Non-empty symbolic KMap ~= empty KMap: fails"
             symbolicKMapWithOneItem
             emptyKMap
-            (MatchIndeterminate symbolicKMapWithOneItem emptyKMap)
+            (failed $ DifferentValues symbolicKMapWithOneItem emptyKMap)
         , test
-            "Non-empty symbolic KMap on the left, non-empty concrete KMap on the right: indeterminate"
-            symbolicKMapWithOneItem
+            "Non-empty symbolic KMap ~= non-empty concrete KMap, same key: matches contained value"
+            symbolicKMapWithOneItem -- "key" -> A
+            concreteKMapWithOneItem -- "key" -> "value"
+            (success [("A", kmapElementSort, dv kmapElementSort "value")])
+        , test
+            "One key and rest variable ~= same key: Match rest with empty map"
+            concreteKMapWithOneItemAndRest
             concreteKMapWithOneItem
-            (MatchIndeterminate symbolicKMapWithOneItem concreteKMapWithOneItem)
+            (success [("REST", kmapSort, emptyKMap)])
+        , test
+            "One key and rest variable ~= two keys (one the same): Match rest with other key singleton"
+            concreteKMapWithOneItemAndRest
+            concreteKMapWithTwoItems
+            ( let restMap =
+                    KMap
+                        testKMapDefinition
+                        [(dv kmapKeySort "key2", dv kmapElementSort "value2")]
+                        Nothing
+               in success [("REST", kmapSort, restMap)]
+            )
+        , -- pattern has more assocs than subject
+          let patRest =
+                KMap
+                    testKMapDefinition
+                    [(dv kmapKeySort "key2", dv kmapElementSort "value2")]
+                    Nothing
+           in test
+                "Extra concrete key in pattern, no rest in subject: fail on rest"
+                concreteKMapWithTwoItems
+                concreteKMapWithOneItem
+                (failed $ DifferentValues patRest emptyKMap)
+        , let patRest =
+                KMap
+                    testKMapDefinition
+                    [(dv kmapKeySort "key2", dv kmapElementSort "value2")]
+                    Nothing
+           in test
+                "Extra concrete key in pattern, opaque rest in subject: indeterminate part"
+                concreteKMapWithTwoItems
+                concreteKMapWithOneItemAndRest
+                (MatchIndeterminate patRest (var "REST" kmapSort))
+        , -- cases with disjoint keys
+          test
+            "Variable key ~= concrete key (and common element) without rest: match key"
+            concreteAndSymbolicKMapWithTwoItems
+            concreteKMapWithTwoItems
+            ( success [("A", kmapKeySort, dv kmapKeySort "key2")]
+            )
+        , let patMap =
+                KMap
+                    testKMapDefinition
+                    [(var "K" kmapKeySort, var "V" kmapElementSort)]
+                    (Just $ var "PATTERN" kmapSort)
+           in test
+                "Variable key ~= concrete key with rest in subject and pattern: indeterminate"
+                patMap
+                functionKMapWithOneItemAndRest
+                (MatchIndeterminate patMap functionKMapWithOneItemAndRest)
+        , let patMap =
+                KMap
+                    testKMapDefinition
+                    [(var "K" kmapKeySort, var "V" kmapElementSort)]
+                    (Just $ var "PATTERN" kmapSort)
+           in test
+                "Variable key and opaque rest ~= two items: indeterminate"
+                patMap
+                concreteKMapWithTwoItems
+                (MatchIndeterminate patMap concreteKMapWithTwoItems)
+        , test
+            "Keys disjoint and pattern keys are fully-concrete: fail"
+            concreteKMapWithOneItemAndRest
+            functionKMapWithOneItem
+            (failed $ DifferentValues concreteKMapWithOneItemAndRest functionKMapWithOneItem)
+        , let patMap =
+                KMap
+                    testKMapDefinition
+                    [ (var "A" kmapKeySort, dv kmapElementSort "a")
+                    , (var "B" kmapKeySort, dv kmapElementSort "b")
+                    ]
+                    (Just $ var "PATTERN" kmapSort)
+              subjMap =
+                KMap
+                    testKMapDefinition
+                    [ (dv kmapKeySort "k1", dv kmapElementSort "a")
+                    , (dv kmapKeySort "k2", dv kmapElementSort "b")
+                    ]
+                    (Just $ var "SUBJECT" kmapSort)
+           in test
+                "Disjoint non-singleton maps, non-concrete keys in pattern: indeterminate"
+                patMap
+                subjMap
+                (MatchIndeterminate patMap subjMap)
         ]
 
 cornerCases :: TestTree

--- a/unit-tests/Test/Booster/Pattern/Match.hs
+++ b/unit-tests/Test/Booster/Pattern/Match.hs
@@ -227,29 +227,18 @@ kmapTerms =
             "One key and rest variable ~= two keys (one the same): Match rest with other key singleton"
             concreteKMapWithOneItemAndRest
             concreteKMapWithTwoItems
-            ( let restMap =
-                    KMap
-                        testKMapDefinition
-                        [(dv kmapKeySort "key2", dv kmapElementSort "value2")]
-                        Nothing
+            ( let restMap = kmap [(dv kmapKeySort "key2", dv kmapElementSort "value2")] Nothing
                in success [("REST", kmapSort, restMap)]
             )
         , -- pattern has more assocs than subject
-          let patRest =
-                KMap
-                    testKMapDefinition
-                    [(dv kmapKeySort "key2", dv kmapElementSort "value2")]
-                    Nothing
+          let patRest = kmap [(dv kmapKeySort "key2", dv kmapElementSort "value2")] Nothing
            in test
                 "Extra concrete key in pattern, no rest in subject: fail on rest"
                 concreteKMapWithTwoItems
                 concreteKMapWithOneItem
                 (failed $ DifferentValues patRest emptyKMap)
         , let patRest =
-                KMap
-                    testKMapDefinition
-                    [(dv kmapKeySort "key2", dv kmapElementSort "value2")]
-                    Nothing
+                kmap [(dv kmapKeySort "key2", dv kmapElementSort "value2")] Nothing
            in test
                 "Extra concrete key in pattern, opaque rest in subject: indeterminate part"
                 concreteKMapWithTwoItems
@@ -263,20 +252,14 @@ kmapTerms =
             ( success [("A", kmapKeySort, dv kmapKeySort "key2")]
             )
         , let patMap =
-                KMap
-                    testKMapDefinition
-                    [(var "K" kmapKeySort, var "V" kmapElementSort)]
-                    (Just $ var "PATTERN" kmapSort)
+                kmap [(var "K" kmapKeySort, var "V" kmapElementSort)] (Just "PATTERN")
            in test
                 "Variable key ~= concrete key with rest in subject and pattern: indeterminate"
                 patMap
                 functionKMapWithOneItemAndRest
                 (MatchIndeterminate patMap functionKMapWithOneItemAndRest)
         , let patMap =
-                KMap
-                    testKMapDefinition
-                    [(var "K" kmapKeySort, var "V" kmapElementSort)]
-                    (Just $ var "PATTERN" kmapSort)
+                kmap [(var "K" kmapKeySort, var "V" kmapElementSort)] (Just "PATTERN")
            in test
                 "Variable key and opaque rest ~= two items: indeterminate"
                 patMap
@@ -288,25 +271,27 @@ kmapTerms =
             functionKMapWithOneItem
             (failed $ DifferentValues concreteKMapWithOneItemAndRest functionKMapWithOneItem)
         , let patMap =
-                KMap
-                    testKMapDefinition
+                kmap
                     [ (var "A" kmapKeySort, dv kmapElementSort "a")
                     , (var "B" kmapKeySort, dv kmapElementSort "b")
                     ]
-                    (Just $ var "PATTERN" kmapSort)
+                    (Just "PATTERN")
               subjMap =
-                KMap
-                    testKMapDefinition
+                kmap
                     [ (dv kmapKeySort "k1", dv kmapElementSort "a")
                     , (dv kmapKeySort "k2", dv kmapElementSort "b")
                     ]
-                    (Just $ var "SUBJECT" kmapSort)
+                    (Just "SUBJECT")
            in test
                 "Disjoint non-singleton maps, non-concrete keys in pattern: indeterminate"
                 patMap
                 subjMap
                 (MatchIndeterminate patMap subjMap)
         ]
+  where
+    kmap :: [(Term, Term)] -> Maybe VarName -> Term
+    kmap assocs mbRestVar =
+        KMap testKMapDefinition assocs $ fmap (`var` kmapSort) mbRestVar
 
 cornerCases :: TestTree
 cornerCases =


### PR DESCRIPTION
Previously, only fully concrete maps (all keys and values identical) would have matched, which is highly unlikely when matching simplification rules.

Now we compare the key sets for (syntactic) equality after substituting with the current substitution, and then try to perform matching on the remainder if a solution is at all possible.

Most importantly, maps of fully-concrete keys can now be handled, matching the contained values. In addition, the case of matching a single unknown key out of a singleton map (i.e., without opaque rest in the subject map) is now possible.

Any ambiguous case is still rejected as `MatchIndeterminate` but some cases can be decided as `MatchFailed` immediately.

Aims to address problems reported in #498 