### PR TITLE
Replace usages of `priorities`, `require`, and `import`

### DIFF
--- a/test/llvm-integration/definition/llvm.k
+++ b/test/llvm-integration/definition/llvm.k
@@ -59,7 +59,7 @@ module MAP-VAL-TO-VAL
 
   syntax MapValToVal ::= MapValToVal "[" key: Val "<-" value: Val "]" [function, total, klabel(MapVal2Val:update), symbol, hook(MAP.update), prefer]
 
-  syntax priorities _Val2Val|->_ > _MapValToVal_ .MapValToVal
+  syntax priority _Val2Val|->_ > _MapValToVal_ .MapValToVal
   syntax non-assoc _Val2Val|->_
 
   syntax MapValToVal ::= MapValToVal "{{" key: Val "<-" value: Val "}}"

--- a/test/rpc-integration/resources/a-to-f/test.k
+++ b/test/rpc-integration/resources/a-to-f/test.k
@@ -1,5 +1,5 @@
 module TEST
-  import BOOL
+  imports BOOL
 
   syntax State ::= "a" [token]
                  | "b" [token]

--- a/test/rpc-integration/resources/diamond/test.k
+++ b/test/rpc-integration/resources/diamond/test.k
@@ -1,6 +1,6 @@
 module TEST
-  import INT
-  import BOOL
+  imports INT
+  imports BOOL
 
   syntax State ::= "init" [token]
                  | "a"    [token]

--- a/test/rpc-integration/resources/equalK-conditions.k
+++ b/test/rpc-integration/resources/equalK-conditions.k
@@ -1,6 +1,6 @@
 module TEST
-  import BOOL
-  import K-EQUAL
+  imports BOOL
+  imports K-EQUAL
 
   syntax State ::= St1()
                  | St2()

--- a/test/rpc-integration/resources/substitutions/test.k
+++ b/test/rpc-integration/resources/substitutions/test.k
@@ -1,5 +1,5 @@
 module TEST
-  import INT
+  imports INT
 
   syntax State ::= "symbolic-subst" [token]
                  | "concrete-subst" [token]


### PR DESCRIPTION
Part of runtimeverification/k#4009

Replace usages of deprecated tokens:

- `syntax priorities` with `syntax priority`
- `require` with `requires`
- `import` with `imports`