### PR TITLE
Hotfix add labelled rule logging for kore

### DIFF
--- a/tools/booster/Server.hs
+++ b/tools/booster/Server.hs
@@ -229,7 +229,10 @@ koreExtraLogs =
     Map.map (Set.fromList . mapMaybe (`Map.lookup` Log.textToType Log.registry)) $
         Map.fromList
             [ (LevelOther "SimplifyKore", ["DebugAttemptEquation", "DebugApplyEquation"])
-            , (LevelOther "RewriteKore", ["DebugAttemptedRewriteRules", "DebugAppliedRewriteRules"])
+            ,
+                ( LevelOther "RewriteKore"
+                , ["DebugAttemptedRewriteRules", "DebugAppliedLabeledRewriteRule", "DebugAppliedRewriteRules"]
+                )
             , (LevelOther "SimplifySuccess", ["DebugApplyEquation"])
             , (LevelOther "RewriteSuccess", ["DebugAppliedRewriteRules"])
             ]

--- a/tools/booster/Stats.hs
+++ b/tools/booster/Stats.hs
@@ -43,13 +43,13 @@ instance (Floating a, PrintfArg a, Ord a) => Pretty (RequestStats a) where
                 <+> withUnit stats.average
                 <+> parens ("+-" <+> withUnit stats.stddev)
                 <> ", range"
-                    <+> brackets (withUnit stats.minVal <> ", " <> withUnit stats.maxVal)
+                <+> brackets (withUnit stats.minVal <> ", " <> withUnit stats.maxVal)
             , "Total time in kore-rpc code:"
                 <+> withUnit stats.koreTotal
             , "Average time per request in kore-rpc code:"
                 <+> withUnit stats.koreAverage
                 <> ", max"
-                    <+> withUnit stats.koreMax
+                <+> withUnit stats.koreMax
             ]
       where
         withUnit = pretty . microsWithUnit

--- a/tools/booster/Stats.hs
+++ b/tools/booster/Stats.hs
@@ -43,13 +43,13 @@ instance (Floating a, PrintfArg a, Ord a) => Pretty (RequestStats a) where
                 <+> withUnit stats.average
                 <+> parens ("+-" <+> withUnit stats.stddev)
                 <> ", range"
-                <+> brackets (withUnit stats.minVal <> ", " <> withUnit stats.maxVal)
+                    <+> brackets (withUnit stats.minVal <> ", " <> withUnit stats.maxVal)
             , "Total time in kore-rpc code:"
                 <+> withUnit stats.koreTotal
             , "Average time per request in kore-rpc code:"
                 <+> withUnit stats.koreAverage
                 <> ", max"
-                <+> withUnit stats.koreMax
+                    <+> withUnit stats.koreMax
             ]
       where
         withUnit = pretty . microsWithUnit


### PR DESCRIPTION
The rule logging used for `kore-rpc` in log level `RewriteKore` outputs rule locations but not rule labels for successful rewrites. This PR adds another log option which outputs each applied rule with its label.
This is important for rules added via `add-module` requests which don't usually have rule locations  (but do have labels).
