### PR TITLE
Remove spurious newline from log messages

### DIFF
--- a/library/Booster/Util.hs
+++ b/library/Booster/Util.hs
@@ -111,7 +111,7 @@ handleOutput ::
     IO ()
 handleOutput levelToHandle loc src level msg =
     let bytes = Log.fromLogStr $ Log.defaultLogStr loc src level msg
-     in BS.hPutStrLn (levelToHandle level) bytes
+     in BS.hPutStr (levelToHandle level) bytes
 
 -- | Run a logging computation, redirecting various levels to the handles specified by the first arguments
 runHandleLoggingT :: (Log.LogLevel -> IO.Handle) -> Log.LoggingT m a -> m a


### PR DESCRIPTION
I did not realize  that `defaultLogStr` already adds a newline at the end --- no need to use `hPutStrLn`