### PR TITLE
Remove code that handles outputting eventlog into a file

### DIFF
--- a/library/Booster/CLOptions.hs
+++ b/library/Booster/CLOptions.hs
@@ -34,7 +34,6 @@ data CLOptions = CLOptions
     , equationOptions :: EquationOptions
     , -- developer options below
       eventlogEnabledUserEvents :: [CustomUserEventType]
-    , hijackEventlogFile :: Maybe FilePath
     }
     deriving (Show)
 
@@ -93,14 +92,6 @@ clOptionsParser =
                                 ", "
                                 [toKebab $ fromHumps $ show t | t <- [minBound .. maxBound] :: [CustomUserEventType]]
                         )
-                )
-            )
-        <*> optional
-            ( strOption
-                ( metavar "HIJACK_EVENTLOG_FILE"
-                    <> long "hijack-eventlog-file"
-                    <> help
-                        "Hijack LlvmCall tracing events and write them to a file to overcome GHC RTS' restriction on event size (2^16 bytes). Avoid at all costs."
                 )
             )
   where


### PR DESCRIPTION
This functionality is not useful, and can be implemented on top of the JSON-logging infrastructure introduced in #516