### PR TITLE
Separate llvm pass from equation evaluator

### DIFF
--- a/library/Booster/Pattern/ApplyEquations.hs
+++ b/library/Booster/Pattern/ApplyEquations.hs
@@ -155,7 +155,18 @@ data EquationState = EquationState
     , cache :: SimplifierCache
     }
 
-type SimplifierCache = Map Term Term
+data SimplifierCache = SimplifierCache {llvm, equations :: Map Term Term}
+    deriving stock (Show)
+
+instance Semigroup SimplifierCache where
+    cache1 <> cache2 =
+        SimplifierCache (cache1.llvm <> cache2.llvm) (cache1.equations <> cache2.equations)
+
+instance Monoid SimplifierCache where
+    mempty = SimplifierCache mempty mempty
+
+data CacheTag = LLVM | Equations
+    deriving stock (Show)
 
 data EquationMetadata = EquationMetadata
     { location :: Maybe Location
@@ -246,7 +257,7 @@ isMatchFailure _ = False
 isSuccess EquationApplied{} = True
 isSuccess _ = False
 
-startState :: Map Term Term -> EquationState
+startState :: SimplifierCache -> EquationState
 startState cache =
     EquationState
         { termStack = mempty
@@ -295,11 +306,19 @@ popRecursion = do
         then throw $ InternalError "Trying to pop an empty recursion stack"
         else eqState $ put s{recursionStack = tail s.recursionStack}
 
-toCache :: MonadLoggerIO io => Term -> Term -> EquationT io ()
-toCache orig result = eqState . modify $ \s -> s{cache = Map.insert orig result s.cache}
+toCache :: MonadLoggerIO io => CacheTag -> Term -> Term -> EquationT io ()
+toCache tag orig result = eqState . modify $ \s -> s{cache = updateCache tag s.cache}
+  where
+    insertInto = Map.insert orig result
+    updateCache LLVM cache = cache{llvm = insertInto cache.llvm}
+    updateCache Equations cache = cache{equations = insertInto cache.equations}
 
-fromCache :: MonadLoggerIO io => Term -> EquationT io (Maybe Term)
-fromCache t = eqState $ Map.lookup t <$> gets (.cache)
+fromCache :: MonadLoggerIO io => CacheTag -> Term -> EquationT io (Maybe Term)
+fromCache tag t = eqState $ Map.lookup t <$> gets (select tag . (.cache))
+  where
+    select :: CacheTag -> SimplifierCache -> Map Term Term
+    select LLVM = (.llvm)
+    select Equations = (.equations)
 
 checkForLoop :: MonadLoggerIO io => Term -> EquationT io ()
 checkForLoop t = do
@@ -392,6 +411,15 @@ llvmEval definition api = eval
   where
     eval t@(Term attributes _)
         | attributes.isEvaluated = pure t
+        | otherwise =
+            fromCache LLVM t >>= \case
+                Nothing ->
+                    eval' t
+                Just cached ->
+                    when (cached /= t) setChanged >> pure cached
+
+    eval' t@(Term attributes _)
+        | attributes.isEvaluated = pure t
         | isConcrete t && attributes.canBeEvaluated = do
             LLVM.simplifyTerm api definition t (sortOfTerm t)
                 >>= \case
@@ -399,12 +427,12 @@ llvmEval definition api = eval
                     Right result -> do
                         when (result /= t) $ do
                             setChanged
-                            toCache t result
                             emitEquationTrace t Nothing (Just "LLVM") Nothing $ Success result
+                        toCache LLVM t result
                         pure result
         | otherwise = do
             result <- descend t
-            when (t /= result) $ toCache t result
+            toCache LLVM t result
             pure result
     descend = \case
         dv@DomainValue{} -> pure dv
@@ -524,10 +552,10 @@ applyTerm direction pref trm = do
     descend config t@(Term attributes _)
         | attributes.isEvaluated = pure t
         | otherwise =
-            fromCache t >>= \case
+            fromCache Equations t >>= \case
                 Nothing -> do
                     simplified <- apply config t
-                    when (t /= simplified) $ toCache t simplified
+                    toCache Equations t simplified
                     pure simplified
                 Just cached -> do
                     when (t /= cached) $ do


### PR DESCRIPTION
This PR changes the `iterateEquations` procedure to first evaluate all suitable (concrete, unevaluated, evaluatable) subterms using the LLVM library (if one is provided), before simplifying and evaluating the term using equations.
Two separate caches are necessary to store the prior results.

Built-in hook evaluation and equation-based evaluation are still combined (trying hooks first) because both should be done bottom-up while the LLVM-based evaluation should traverse top-down (to cut the traversal).

Related to #539 (and #517 )