### PR TITLE
Add an OrTerm constructor

### DIFF
--- a/library/Booster/Definition/Ceil.hs
+++ b/library/Booster/Definition/Ceil.hs
@@ -156,6 +156,7 @@ computeCeil term@(SymbolApplication symbol _ args)
                 argCeils <- concatMapM computeCeil args
                 pure $ (map Left $ splitBoolPredicates $ Predicate simplified) <> argCeils
 computeCeil (AndTerm l r) = concatMapM computeCeil [l, r]
+computeCeil (OrTerm l r) = concatMapM computeCeil [l, r] -- TODO: Is this too much of an overapproximation? I dont think it should be Ceil(l) \/ Ceil(r)...
 computeCeil (Injection _ _ t) = computeCeil t
 computeCeil (KMap _ keyVals rest) = do
     recArgs <- concatMapM computeCeil $ concat [[k, v] | (k, v) <- keyVals] <> maybeToList rest

--- a/library/Booster/LLVM/Internal.hs
+++ b/library/Booster/LLVM/Internal.hs
@@ -419,6 +419,12 @@ marshallTerm t = do
             trm <- liftIO $ kore.patt.fromSymbol andSym
             void $ liftIO . kore.patt.addArgument trm =<< marshallTerm l
             liftIO . kore.patt.addArgument trm =<< marshallTerm r
+        OrTerm l r -> do
+            andSym <- liftIO $ kore.symbol.new "\\or"
+            void $ liftIO . kore.symbol.addArgument andSym =<< marshallSort (sortOfTerm l)
+            trm <- liftIO $ kore.patt.fromSymbol andSym
+            void $ liftIO . kore.patt.addArgument trm =<< marshallTerm l
+            liftIO . kore.patt.addArgument trm =<< marshallTerm r
         DomainValue sort val ->
             marshallSort sort >>= liftIO . kore.patt.token.new val
         Var varName -> error $ "marshalling Var " <> show varName <> " unsupported"

--- a/library/Booster/Pattern/ApplyEquations.hs
+++ b/library/Booster/Pattern/ApplyEquations.hs
@@ -443,6 +443,10 @@ llvmEval definition api = eval
             AndTerm -- no \and simplification
                 <$> eval arg1
                 <*> eval arg2
+        OrTerm arg1 arg2 ->
+            OrTerm -- no \or simplification
+                <$> eval arg1
+                <*> eval arg2
         SymbolApplication sym sorts args ->
             SymbolApplication sym sorts <$> mapM eval args
         KMap def keyVals rest ->
@@ -574,6 +578,10 @@ applyTerm direction pref trm = do
             Injection src trg <$> descend config t -- no injection simplification
         AndTerm arg1 arg2 ->
             AndTerm -- no \and simplification
+                <$> descend config arg1
+                <*> descend config arg2
+        OrTerm arg1 arg2 ->
+            OrTerm -- no \or simplification
                 <$> descend config arg1
                 <*> descend config arg2
         app@(SymbolApplication sym sorts args)

--- a/library/Booster/Pattern/Binary.hs
+++ b/library/Booster/Pattern/Binary.hs
@@ -482,6 +482,7 @@ encodeTerm = \case
         putWord8 KORECompositePattern
         encodeLength 1
     AndTerm t1 t2 -> encodeSymbolApplication "\\and" [sortOfTerm t1] [Left t1, Left t2]
+    OrTerm t1 t2 -> encodeSymbolApplication "\\or" [sortOfTerm t1] [Left t1, Left t2]
     Injection source target t -> encodeSymbolApplication "inj" [source, target] [Left t]
     KMap def keyVals rest -> encodeTerm $ externaliseKmapUnsafe def keyVals rest
     KList def heads rest -> encodeTerm $ externaliseKList def heads rest

--- a/library/Booster/Pattern/Match.hs
+++ b/library/Booster/Pattern/Match.hs
@@ -188,11 +188,11 @@ match1
 ----- Or Terms
 -- indeterminate
 match1
-    term1@AndTerm{}
+    term1@OrTerm{}
     term2 = indeterminate term1 term2
 match1
     term1
-    term2@AndTerm{} = indeterminate term1 term2
+    term2@OrTerm{} = indeterminate term1 term2
 ----- Domain values
 match1
     d1@(DomainValue s1 t1)

--- a/library/Booster/Pattern/Match.hs
+++ b/library/Booster/Pattern/Match.hs
@@ -185,6 +185,14 @@ match1
     pat
     andTerm@AndTerm{} =
         indeterminate pat andTerm
+----- Or Terms
+-- indeterminate
+match1
+    term1@AndTerm{}
+    term2 = indeterminate term1 term2
+match1
+    term1
+    term2@AndTerm{} = indeterminate term1 term2
 ----- Domain values
 match1
     d1@(DomainValue s1 t1)

--- a/library/Booster/Pattern/Unify.hs
+++ b/library/Booster/Pattern/Unify.hs
@@ -201,11 +201,11 @@ unify1
 ----- Or Terms
 -- indeterminate
 unify1
-    term1@AndTerm{}
+    term1@OrTerm{}
     term2 = addIndeterminate term1 term2
 unify1
     term1
-    term2@AndTerm{} = addIndeterminate term1 term2
+    term2@OrTerm{} = addIndeterminate term1 term2
 ----- Injections
 -- two injections. Try to unify the contained terms if the sorts
 -- agree. Target sorts must be the same, source sorts may differ if

--- a/library/Booster/Pattern/Unify.hs
+++ b/library/Booster/Pattern/Unify.hs
@@ -198,6 +198,14 @@ unify1
         do
             enqueueRegularProblem term1 t2a
             enqueueRegularProblem term1 t2b
+----- Or Terms
+-- indeterminate
+unify1
+    term1@AndTerm{}
+    term2 = addIndeterminate term1 term2
+unify1
+    term1
+    term2@AndTerm{} = addIndeterminate term1 term2
 ----- Injections
 -- two injections. Try to unify the contained terms if the sorts
 -- agree. Target sorts must be the same, source sorts may differ if

--- a/library/Booster/Syntax/Json/Externalise.hs
+++ b/library/Booster/Syntax/Json/Externalise.hs
@@ -62,6 +62,12 @@ externaliseTerm = \case
             [ externaliseTerm first'
             , externaliseTerm second'
             ]
+    Internal.OrTerm first' second' ->
+        Syntax.KJOr
+            (externaliseSort $ sortOfTerm second')
+            [ externaliseTerm first'
+            , externaliseTerm second'
+            ]
     Internal.SymbolApplication symbol sorts args ->
         Syntax.KJApp
             (symbolNameToId symbol.name)

--- a/library/Booster/Syntax/Json/Internalise.hs
+++ b/library/Booster/Syntax/Json/Internalise.hs
@@ -281,7 +281,12 @@ internaliseTermRaw qq allowAlias checkSubsorts sortVars definition@KoreDefinitio
             -- TODO check that both a and b are of sort "resultSort"
             -- Which is a unification problem if this involves variables.
             pure $ foldr1 Internal.AndTerm args
-        Syntax.KJOr{} -> predicate
+        Syntax.KJOr{patterns} -> do
+            -- analysed beforehand, expecting this to operate on terms
+            args <- mapM recursion patterns
+            -- TODO check that both a and b are of sort "resultSort"
+            -- Which is a unification problem if this involves variables.
+            pure $ foldr1 Internal.OrTerm args
         Syntax.KJImplies{} -> predicate
         Syntax.KJIff{} -> predicate
         Syntax.KJForall{} -> predicate
@@ -722,6 +727,7 @@ renderSortError = \case
 recomputeTermAttributes :: Internal.Term -> Internal.Term
 recomputeTermAttributes = \case
     Internal.AndTerm t1 t2 -> Internal.AndTerm (recomputeTermAttributes t1) (recomputeTermAttributes t2)
+    Internal.OrTerm t1 t2 -> Internal.OrTerm (recomputeTermAttributes t1) (recomputeTermAttributes t2)
     Internal.SymbolApplication sym sorts args -> Internal.SymbolApplication sym sorts $ map recomputeTermAttributes args
     Internal.DomainValue sort dv -> Internal.DomainValue sort dv
     Internal.Var v -> Internal.Var v


### PR DESCRIPTION
Fixes #545. This allows internalising #Or terms, however we cannot match/unify on rules containing these for now.