### PR TITLE
Unbound variable check when internalising module

### DIFF
--- a/library/Booster/Pattern/Util.hs
+++ b/library/Booster/Pattern/Util.hs
@@ -13,6 +13,7 @@ module Booster.Pattern.Util (
     modifyVarName,
     modifyVarNameConcreteness,
     freeVariables,
+    freeVariablesPattern,
     isConstructorSymbol,
     isSortInjectionSymbol,
     isFunctionSymbol,
@@ -199,6 +200,9 @@ modifyVarNameConcreteness f = \case
 
 freeVariables :: Term -> Set Variable
 freeVariables (Term attributes _) = attributes.variables
+
+freeVariablesPattern :: Pattern -> Set Variable
+freeVariablesPattern p = Set.unions $ map freeVariables $ p.term : (map coerce . Set.toList) p.constraints
 
 isConcrete :: Term -> Bool
 isConcrete = Set.null . freeVariables

--- a/library/Booster/Prettyprinter.hs
+++ b/library/Booster/Prettyprinter.hs
@@ -28,6 +28,7 @@ module Booster.Prettyprinter (
     escapeCharT,
     unparseAssoc',
     unparseConcat',
+    list,
 ) where
 
 import Control.Arrow ((>>>)) -- TODO: remove


### PR DESCRIPTION
Check whether all existential variables are quantified when internalising rules. This is to prevent runtimeverification/haskell-backend#3777, where the rule contains a variable on the RHS which does not appear on the LHS and should therefore be existentially quantified, since this is the assumption that the booster currently makes and we leak internal variable names when this assumption is violated (we could drop using explicit `\exist` altogether and just infer exist variables automatically).

With this change, sending this request:

```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "add-module",
  "params": {
    "module": "module M-SIMPLE-PROOFS-SPEC-USE-DEPS1-DEPENDS-MODULE\n    import SIMPLE-PROOFS []\n    axiom{} \\rewrites{SortGeneratedTopCell{}}(\\and{SortGeneratedTopCell{}}(Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStep{}, SortKItem{}}(Lblstart1'Unds'SIMPLE-PROOFS'Unds'Step{}()), dotk{}())), Lbl'-LT-'state'-GT-'{}(Var'Unds'STATE'Unds'CELL : SortMap{}), Lbl'-LT-'generatedCounter'-GT-'{}(Var'Unds'GENERATEDCOUNTER'Unds'CELL'Unds'c84b0b5f : SortInt{})), \\top{SortGeneratedTopCell{}}()), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStep{}, SortKItem{}}(Lblmid'Unds'SIMPLE-PROOFS'Unds'Step{}()), dotk{}())), Lbl'-LT-'state'-GT-'{}(Var'Unds'STATE'Unds'CELL : SortMap{}), Lbl'-LT-'generatedCounter'-GT-'{}(Var'QuesUnds'GENERATEDCOUNTER'Unds'CELL'Unds'6de8d71b : SortInt{}))) [priority{}(\"20\"), label{}(\"BASIC-BLOCK-1-TO-2\")]\nendmodule []",
    "name-as-id": true
  }
}
```

will result in the following error:

```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "error": {
    "code": 8,
    "data": {
      "context": null,
      "error": "Unbound variables Var?_GENERATEDCOUNTER_CELL_6de8d71b:SortInt{} in rule BASIC-BLOCK-1-TO-2"
    },
    "message": "Invalid module"
  }
}
```