### PR TITLE
More information on equations in logs

### DIFF
--- a/library/Booster/Pattern/ApplyEquations.hs
+++ b/library/Booster/Pattern/ApplyEquations.hs
@@ -31,6 +31,7 @@ module Booster.Pattern.ApplyEquations (
     SimplifierCache,
 ) where
 
+import Control.Applicative (Alternative (..))
 import Control.Monad
 import Control.Monad.Extra (fromMaybeM, whenJust)
 import Control.Monad.IO.Class (MonadIO (..))
@@ -264,9 +265,8 @@ isSuccess _ = False
   as neither of these categories have unique IDs.
 -}
 equationRuleIdWithFallbacks :: EquationMetadata -> Text
-equationRuleIdWithFallbacks metadata = case fmap getUniqueId metadata.ruleId of
-    Nothing -> fromMaybe "UNKNOWN" metadata.label
-    Just x -> x
+equationRuleIdWithFallbacks metadata =
+    fromMaybe "UNKNOWN" (fmap getUniqueId metadata.ruleId <|> metadata.label)
 
 equationTraceToLogEntry :: EquationTrace Term -> KoreRpcLog.LogEntry
 equationTraceToLogEntry = \case

--- a/library/Booster/Pattern/ApplyEquations.hs
+++ b/library/Booster/Pattern/ApplyEquations.hs
@@ -606,7 +606,8 @@ cached cacheTag cb t@(Term attributes _)
             Just cachedTerm -> do
                 when (t /= cachedTerm) $ do
                     setChanged
-                    emitEquationTrace t Nothing (Just "Cache") Nothing $ Success cachedTerm
+                    emitEquationTrace t Nothing (Just ("Cache" <> Text.pack (show cacheTag))) Nothing $
+                        Success cachedTerm
                 pure cachedTerm
 
 elseApply :: (Monad m, Eq b) => (b -> m b) -> (b -> m b) -> b -> m b


### PR DESCRIPTION
- for cached equation applications, specify which cache they came from
- if rule id is not available (usually for LLVM simplifications), emit the rule label instead.