### PR TITLE
Compute hashes correctly when constructing internalised collections

### DIFF
--- a/library/Booster/Pattern/Base.hs
+++ b/library/Booster/Pattern/Base.hs
@@ -630,9 +630,9 @@ pattern KList def heads rest <- Term _ (KListF def heads rest)
                             Hashable.hash
                                 ( "KList" :: ByteString
                                 , def
-                                , map (hash . getAttributes) heads
-                                , fmap (hash . getAttributes . fst) rest
-                                , fmap (map (hash . getAttributes) . snd) rest
+                                , map (hash . getAttributes) newHeads
+                                , fmap (hash . getAttributes . fst) newRest
+                                , fmap (map (hash . getAttributes) . snd) newRest
                                 )
                         }
                     $ KListF def newHeads newRest
@@ -662,8 +662,8 @@ pattern KSet def elements rest <- Term _ (KSetF def elements rest)
                             Hashable.hash
                                 ( "KSet" :: ByteString
                                 , def
-                                , map (hash . getAttributes) elements
-                                , fmap (hash . getAttributes) rest
+                                , map (hash . getAttributes) newElements
+                                , fmap (hash . getAttributes) newRest
                                 )
                         }
                     $ KSetF def newElements newRest

--- a/library/Booster/Pattern/Base.hs
+++ b/library/Booster/Pattern/Base.hs
@@ -587,7 +587,7 @@ pattern KMap def keyVals rest <- Term _ (KMapF def keyVals rest)
                         (_ : _, Just r) ->
                             foldl' (<>) (getAttributes r) $ concatMap (\(k, v) -> [getAttributes k, getAttributes v]) keyVals
                 (keyVals', rest') = case rest of
-                    Just (KMap def' kvs r) | def' == def -> (kvs, r)
+                    Just (KMap def' kvs r) | def' == def -> (Set.toList . Set.fromList $ kvs, r)
                     r -> ([], r)
                 newKeyVals = Set.toList $ Set.fromList $ keyVals ++ keyVals'
                 newRest = rest'
@@ -656,7 +656,7 @@ pattern KSet def elements rest <- Term _ (KSetF def elements rest)
                             error $ "Inconsistent set definition " <> show (def, def')
                         | otherwise ->
                             (Set.toList . Set.fromList $ elements <> elements', rest')
-                    other -> (elements, other)
+                    other -> (Set.toList . Set.fromList $ elements, other)
              in Term
                     argAttributes
                         { hash =

--- a/library/Booster/Pattern/Base.hs
+++ b/library/Booster/Pattern/Base.hs
@@ -588,16 +588,19 @@ pattern KMap def keyVals rest <- Term _ (KMapF def keyVals rest)
                 (keyVals', rest') = case rest of
                     Just (KMap def' kvs r) | def' == def -> (kvs, r)
                     r -> ([], r)
+                newKeyVals = Set.toList $ Set.fromList $ keyVals ++ keyVals'
+                newRest = rest'
              in Term
                     argAttributes
+                        { hash =
                             Hashable.hash
                                 ( "KMap" :: ByteString
                                 , def
-                                , map (\(k, v) -> (hash $ getAttributes k, hash $ getAttributes v)) keyVals
-                                , hash . getAttributes <$> rest
+                                , map (\(k, v) -> (hash $ getAttributes k, hash $ getAttributes v)) newKeyVals
+                                , hash . getAttributes <$> newRest
                                 )
                         }
-                    $ KMapF def (Set.toList $ Set.fromList $ keyVals ++ keyVals') rest'
+                    $ KMapF def newKeyVals newRest
 
 pattern KList :: KListDefinition -> [Term] -> Maybe (Term, [Term]) -> Term
 pattern KList def heads rest <- Term _ (KListF def heads rest)

--- a/library/Booster/Pattern/Base.hs
+++ b/library/Booster/Pattern/Base.hs
@@ -590,21 +590,12 @@ pattern KMap def keyVals rest <- Term _ (KMapF def keyVals rest)
                     r -> ([], r)
              in Term
                     argAttributes
-                        { isEvaluated =
-                            -- Constructors and injections are evaluated if their arguments are.
-                            -- Function calls are not evaluated.
-                            argAttributes.isEvaluated
-                        , hash =
                             Hashable.hash
                                 ( "KMap" :: ByteString
                                 , def
                                 , map (\(k, v) -> (hash $ getAttributes k, hash $ getAttributes v)) keyVals
                                 , hash . getAttributes <$> rest
                                 )
-                        , isConstructorLike =
-                            argAttributes.isConstructorLike
-                        , canBeEvaluated =
-                            argAttributes.canBeEvaluated
                         }
                     $ KMapF def (Set.toList $ Set.fromList $ keyVals ++ keyVals') rest'
 

--- a/library/Booster/Pattern/Base.hs
+++ b/library/Booster/Pattern/Base.hs
@@ -591,7 +591,7 @@ pattern KMap def keyVals rest <- Term _ (KMapF def keyVals rest)
                         (_ : _, Just r) ->
                             foldl' (<>) (getAttributes r) $ concatMap (\(k, v) -> [getAttributes k, getAttributes v]) keyVals
                 (keyVals', rest') = case rest of
-                    Just (KMap def' kvs r) | def' == def -> (sortAndDeduplicate kvs, r)
+                    Just (KMap def' kvs r) | def' == def -> (kvs, r)
                     r -> ([], r)
                 newKeyVals = sortAndDeduplicate $ keyVals ++ keyVals'
                 newRest = rest'
@@ -654,13 +654,13 @@ pattern KSet def elements rest <- Term _ (KSetF def elements rest)
                         foldl1' (<>) $ map getAttributes elements
                     | Just r <- rest =
                         foldl' (<>) (getAttributes r) . map getAttributes $ elements
-                (newElements, newRest) = case rest of
-                    Just (KSet def' elements' rest')
-                        | def /= def' ->
-                            error $ "Inconsistent set definition " <> show (def, def')
-                        | otherwise ->
-                            (sortAndDeduplicate $ elements <> elements', rest')
-                    other -> (sortAndDeduplicate elements, other)
+                (elements', rest') = case rest of
+                    Just (KSet def' es r)
+                        | def /= def' -> error $ "Inconsistent set definition " <> show (def, def')
+                        | otherwise -> (es, r)
+                    other -> ([], other)
+                newElements = sortAndDeduplicate $ elements <> elements'
+                newRest = rest'
              in Term
                     argAttributes
                         { hash =

--- a/library/Booster/Pattern/Base.hs
+++ b/library/Booster/Pattern/Base.hs
@@ -37,7 +37,7 @@ import Data.Data (Data)
 import Data.Functor.Foldable
 import Data.Hashable (Hashable)
 import Data.Hashable qualified as Hashable
-import Data.List as List (foldl1', sort)
+import Data.List as List (foldl', foldl1', sort)
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Text qualified as Text
@@ -584,7 +584,8 @@ pattern KMap def keyVals rest <- Term _ (KMapF def keyVals rest)
                         ([], Nothing) -> mempty
                         ([], Just s) -> getAttributes s
                         (_ : _, Nothing) -> foldl1' (<>) $ concatMap (\(k, v) -> [getAttributes k, getAttributes v]) keyVals
-                        (_ : _, Just r) -> foldr (<>) (getAttributes r) $ concatMap (\(k, v) -> [getAttributes k, getAttributes v]) keyVals
+                        (_ : _, Just r) ->
+                            foldl' (<>) (getAttributes r) $ concatMap (\(k, v) -> [getAttributes k, getAttributes v]) keyVals
                 (keyVals', rest') = case rest of
                     Just (KMap def' kvs r) | def' == def -> (kvs, r)
                     r -> ([], r)
@@ -613,7 +614,7 @@ pattern KList def heads rest <- Term _ (KListF def heads rest)
                         (nonEmpty, Nothing) ->
                             foldl1' (<>) $ map getAttributes nonEmpty
                         (_, Just (m, tails)) ->
-                            foldr ((<>) . getAttributes) (getAttributes m) $ heads <> tails
+                            foldl' (<>) (getAttributes m) . map getAttributes $ heads <> tails
                 (newHeads, newRest) = case rest of
                     Just (KList def' heads' rest', tails)
                         | def' /= def ->
@@ -648,7 +649,7 @@ pattern KSet def elements rest <- Term _ (KSetF def elements rest)
                     | Nothing <- rest =
                         foldl1' (<>) $ map getAttributes elements
                     | Just r <- rest =
-                        foldr ((<>) . getAttributes) (getAttributes r) elements
+                        foldl' (<>) (getAttributes r) . map getAttributes $ elements
                 (newElements, newRest) = case rest of
                     Just (KSet def' elements' rest')
                         | def /= def' ->

--- a/test/llvm-integration/LLVM.hs
+++ b/test/llvm-integration/LLVM.hs
@@ -240,14 +240,15 @@ setProp api = property $ do
                 SymbolApplication
                     (defSymbols Map.! sortSetKSet.symbolNames.concatSymbolName)
                     []
-                    [singletonSet x, singletonSet y]
+                    [x, y]
             )
+            . map singletonSet
 
     wrapIntTerm :: Int -> Term
     wrapIntTerm i =
         SymbolApplication
             (defSymbols Map.! "inj")
-            [SortApp "SortInt" [], SortApp "SortKItem" []]
+            [intSort, kItemSort]
             [intTerm i]
 
 ------------------------------------------------------------
@@ -272,7 +273,7 @@ loadAPI = Internal.withDLib dlPath Internal.mkAPI
 ------------------------------------------------------------
 -- term construction
 
-boolSort, intSort, bytesSort, stringSort :: Sort
+boolSort, intSort, bytesSort, stringSort, kItemSort :: Sort
 boolSort = SortApp "SortBool" []
 intSort = SortApp "SortInt" []
 bytesSort = SortApp "SortBytes" []
@@ -384,7 +385,7 @@ sortSetKSet =
                 , concatSymbolName = "Lbl'Unds'Set'Unds'"
                 }
         , elementSortName = "SortKItem"
-        , listSortName = "SortList"
+        , listSortName = "SortSet"
         }
 
 sortListKList :: KListDefinition
@@ -500,6 +501,13 @@ defSorts =
             ,
                 ( SortAttributes{collectionAttributes = Just (sortListKList.symbolNames, KListTag), argCount = 0}
                 , Set.fromList ["SortList"]
+                )
+            )
+        ,
+            ( "SortSet"
+            ,
+                ( SortAttributes{collectionAttributes = Just (sortSetKSet.symbolNames, KSetTag), argCount = 0}
+                , Set.fromList ["SortSet"]
                 )
             )
         ,
@@ -707,7 +715,7 @@ defSymbols =
                 , resultSort = SortApp "SortSet" []
                 , attributes =
                     SymbolAttributes
-                        { collectionMetadata = Nothing
+                        { collectionMetadata = Just $ KSetMeta sortSetKSet
                         , symbolType = TotalFunction
                         , isIdem = IsNotIdem
                         , isAssoc = IsNotAssoc
@@ -827,7 +835,7 @@ defSymbols =
                 , resultSort = SortApp "SortSet" []
                 , attributes =
                     SymbolAttributes
-                        { collectionMetadata = Nothing
+                        { collectionMetadata = Just $ KSetMeta sortSetKSet
                         , symbolType = PartialFunction
                         , isIdem = IsIdem
                         , isAssoc = IsAssoc
@@ -2010,7 +2018,7 @@ defSymbols =
                 , resultSort = SortApp "SortSet" []
                 , attributes =
                     SymbolAttributes
-                        { collectionMetadata = Nothing
+                        { collectionMetadata = Just $ KSetMeta sortSetKSet
                         , symbolType = TotalFunction
                         , isIdem = IsNotIdem
                         , isAssoc = IsNotAssoc

--- a/test/llvm-integration/LLVM.hs
+++ b/test/llvm-integration/LLVM.hs
@@ -102,7 +102,7 @@ llvmSpec =
                     hedgehog . propertyTest . mapKItemInjProp
 
             describe "internalised set tests" $
-                it "show leave concrete sets alone" $
+                it "should leave concrete sets unchanged" $
                     hedgehog . propertyTest . setProp
 
 --------------------------------------------------
@@ -211,7 +211,7 @@ mapKItemInjProp api = property $ do
 
 setProp :: LLVM.API -> Property
 setProp api = property $ do
-    forM_ [2 .. 10] $ \n -> do
+    forM_ [1 .. 10] $ \n -> do
         xs <-
             forAll $
                 Gen.filter (\xs -> xs == nub xs) $
@@ -285,9 +285,6 @@ boolTerm = DomainValue boolSort . BS.pack . map toLower . show
 
 intTerm :: (Integral a, Show a) => a -> Term
 intTerm = DomainValue intSort . BS.pack . show . (+ 0)
-
-intTermKItem :: (Integral a, Show a) => a -> Term
-intTermKItem = DomainValue kItemSort . BS.pack . show . (+ 0)
 
 bytesTerm :: ByteString -> Term
 bytesTerm = DomainValue bytesSort


### PR DESCRIPTION
This PR fixes a bug in the computation of the synthesis bottom-up hash attribute of `Term`s representing internalised maps and sets.
These hashes are used in the `Eq` instance for `Term` to quilcky check if two terms are equal, akin to a Merkle tree.

Summary of changes:
- the commits 348f852, 17005f2 and df6a063 comprise the main fix, i.e. correct how the `KMap` and `KSet` pattern-synonyms compute the hashes;
- b7aac44 makes sure we `foldl'` rather than `foldr` in some of the cases, as we should use the left fold for data as rule of thumb for better performance. I did not check the impact of this commit specifically though;
- there are some more stylistic changes and unit tests for the first change.