### PR TITLE
Updating MacOs CI Build Runners

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -3,7 +3,7 @@ ARG BASE_DISTRO
 ARG HPACK_VERSION
 ARG GHC_VERSION
 
-FROM haskell:${GHC_VERSION}-buster
+FROM haskell:${GHC_VERSION}-bookworm
 
 ENV TZ America/Chicago
 ENV DEBIAN_FRONTEND=noninteractive

--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -12,10 +12,10 @@ ARG HPACK_VERSION
 ARG FOURMOLU_VERSION
 ARG HLINT_VERSION
 
-RUN    apt-get update        \
-    && apt-get install --yes \
+RUN    apt update        \
+    && apt install --yes \
         curl                 \
-        libsecp256k1-0       \
+        libsecp256k1-1       \
         libsecp256k1-dev     \
         libtinfo5            \
         locales              \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,7 +77,7 @@ jobs:
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
 
       - name: 'Install Cachix'
-        uses: cachix/cachix-action@v14
+        uses: cachix/cachix-action@v16
         with:
           name: k-framework
           authToken: '${{ secrets.CACHIX_PUBLIC_TOKEN }}'
@@ -142,7 +142,7 @@ jobs:
 
       - name: 'Install Cachix'
         if: ${{ matrix.os == 'macos-15' }}
-        uses: cachix/cachix-action@v14
+        uses: cachix/cachix-action@v16
         with:
           name: k-framework
           authToken: '${{ secrets.CACHIX_PUBLIC_TOKEN }}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  ghc_version: '9.12.'
+  ghc_version: '9.12.2'
   hpack_version: '0.34.2'
 
 jobs:
@@ -41,19 +41,19 @@ jobs:
       - name: 'Set up Docker'
         uses: ./.github/actions/with-docker
         with:
-          tag: hs-booster-ci-stack-unit-buster-${{ github.run_id }}
+          tag: hs-booster-ci-stack-unit-bookworm-${{ github.run_id }}
           os: ubuntu
           distro: jammy
           hpack: ${{ env.hpack_version }}
           ghc: ${{ env.ghc_version }}
 
       - name: 'Run unit tests'
-        run: docker exec -t hs-booster-ci-stack-unit-buster-${{ github.run_id }} /bin/bash -c 'stack --system-ghc --stack-root $(pwd)/stack-cache test :unit-tests --pedantic'
+        run: docker exec -t hs-booster-ci-stack-unit-bookworm-${{ github.run_id }} /bin/bash -c 'stack --system-ghc --stack-root $(pwd)/stack-cache test :unit-tests --pedantic'
 
       - name: 'Tear down Docker'
         if: always()
         run: |
-          docker stop --time=0 hs-booster-ci-stack-unit-buster-${{ github.run_id }}
+          docker stop --time=0 hs-booster-ci-stack-unit-bookworm-${{ github.run_id }}
 
   style:
     name: 'Formatting and Style'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,9 +68,9 @@ jobs:
           token: ${{ secrets.JENKINS_GITHUB_PAT }}
 
       - name: 'Install Nix'
-        uses: cachix/install-nix-action@v25
+        uses: cachix/install-nix-action@v31.7.0
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
+          install_url: https://releases.nixos.org/nix/nix-2.32.0/install
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
             substituters = http://cache.nixos.org https://cache.iog.io
@@ -132,9 +132,9 @@ jobs:
 
       - name: 'Install Nix'
         if: ${{ matrix.os == 'macos-15' }}
-        uses: cachix/install-nix-action@v22
+        uses: cachix/install-nix-action@v31.7.0
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
+          install_url: https://releases.nixos.org/nix/nix-2.32.0/install
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
             substituters = http://cache.nixos.org https://cache.iog.io

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,11 +117,11 @@ jobs:
           - runner: [self-hosted, linux, normal]
             os: Ubuntu-22.04
             nix: x86_64-linux
-          - runner: MacM1
-            os: self-macos-12
+          - runner: self-macos-latest
+            os: self-macos-latest
             nix: aarch64-darwin
-          - runner: macos-12
-            os: macos-12
+          - runner: macos-15
+            os: macos-15
             nix: x86_64-darwin
     runs-on: ${{ matrix.runner }}
     steps:
@@ -131,7 +131,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: 'Install Nix'
-        if: ${{ matrix.os == 'macos-12' }}
+        if: ${{ matrix.os == 'macos-15' }}
         uses: cachix/install-nix-action@v22
         with:
           install_url: https://releases.nixos.org/nix/nix-2.13.3/install
@@ -141,7 +141,7 @@ jobs:
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
 
       - name: 'Install Cachix'
-        if: ${{ matrix.os == 'macos-12' }}
+        if: ${{ matrix.os == 'macos-15' }}
         uses: cachix/cachix-action@v14
         with:
           name: k-framework
@@ -177,5 +177,5 @@ jobs:
         run: GC_DONT_GC=1 nix develop .#cabal --command bash -c "hpack . && hpack dev-tools && cabal --store-dir ./cabal-cache/store update && cabal --store-dir ./cabal-cache/store test unit-tests --enable-tests --test-show-details=direct"
 
       - name: Integration Tests
-        if: ${{ matrix.os != 'macos-12' }}  ## takes long on public runner, already tested in MacM1
+        if: ${{ matrix.os != 'macos-15' }}  ## takes long on public runner, already tested in MacM1
         run: GC_DONT_GC=1 nix develop .#cabal --command bash -c "scripts/integration-tests.sh"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  ghc_version: '9.6.4'
+  ghc_version: '9.12.'
   hpack_version: '0.34.2'
 
 jobs:
@@ -177,5 +177,5 @@ jobs:
         run: GC_DONT_GC=1 nix develop .#cabal --command bash -c "hpack . && hpack dev-tools && cabal --store-dir ./cabal-cache/store update && cabal --store-dir ./cabal-cache/store test unit-tests --enable-tests --test-show-details=direct"
 
       - name: Integration Tests
-        if: ${{ matrix.os != 'macos-15' }}  ## takes long on public runner, already tested in MacM1
+        if: ${{ matrix.os != 'macos-15' || matrix.os != 'self-macos-latest' }}  ## takes long on public runner, already tested in MacM1
         run: GC_DONT_GC=1 nix develop .#cabal --command bash -c "scripts/integration-tests.sh"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,6 +148,12 @@ jobs:
           authToken: '${{ secrets.CACHIX_PUBLIC_TOKEN }}'
           skipPush: true
 
+      - name: 'Ensure Git repository integrity'
+        run: |
+          git fsck --full
+          git submodule update --init --recursive
+          git clean -ffdx
+
       - name: Build executables
         env:
           CACHIX_AUTH_TOKEN: '${{ secrets.CACHIX_PUBLIC_TOKEN }}'
@@ -172,6 +178,12 @@ jobs:
             cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('package.yaml') }}-${{ hashFiles('dev-tools/package.yaml') }}-
             cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('package.yaml') }}-
             cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-
+
+      - name: 'Clear corrupted Cabal cache (macOS only)'
+        if: ${{ matrix.os == 'self-macos-latest' }}
+        run: |
+          rm -rf cabal-cache/store
+          cabal clean
 
       - name: Unit Tests
         run: GC_DONT_GC=1 nix develop .#cabal --command bash -c "hpack . && hpack dev-tools && cabal --store-dir ./cabal-cache/store update && cabal --store-dir ./cabal-cache/store test unit-tests --enable-tests --test-show-details=direct"

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -38,7 +38,7 @@ jobs:
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
 
       - name: 'Install Cachix'
-        uses: cachix/cachix-action@v14
+        uses: cachix/cachix-action@v16
         with:
           name: k-framework
           authToken: '${{ secrets.CACHIX_PUBLIC_TOKEN }}'

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -29,9 +29,9 @@ jobs:
           git config --global user.email devops@runtimeverification.com
 
       - name: 'Install Nix'
-        uses: cachix/install-nix-action@v22
+        uses: cachix/install-nix-action@v31.7.0
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
+          install_url: https://releases.nixos.org/nix/nix-2.32.0/install
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
             substituters = http://cache.nixos.org https://hydra.iohk.io


### PR DESCRIPTION
MacOS 12 is outdated and deprecated by GH for public runners.  Internally we should target the latest OS